### PR TITLE
Support mounting multiple configurable filesystems

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -106,13 +106,13 @@ void setup_filesystems()
     // An example mount specification looks like:
     //    /dev/mmcblk0p4:/mnt:vfat::utf8
     if (options.extra_mounts) {
-        char *mount = strtok(options.extra_mounts, ",");
-        while (mount) {
-          const char *source = strsep(&mount, ":");
-          const char *target = strsep(&mount, ":");
-          const char *filesystemtype = strsep(&mount, ":");
-          char *mountflags = strsep(&mount, ":");
-          const char *data = strsep(&mount, ":");
+        char *mnt = strtok(options.extra_mounts, ",");
+        while (mnt) {
+          const char *source = strsep(&mnt, ":");
+          const char *target = strsep(&mnt, ":");
+          const char *filesystemtype = strsep(&mnt, ":");
+          char *mountflags = strsep(&mnt, ":");
+          const char *data = strsep(&mnt, ":");
 
           if (source && target && filesystemtype && mountflags && data) {
   #ifndef UNITTEST

--- a/src/fs.c
+++ b/src/fs.c
@@ -106,7 +106,7 @@ void setup_filesystems()
     // An example mount specification looks like:
     //    /dev/mmcblk0p4:/mnt:vfat::utf8
     if (options.extra_mounts) {
-        char *mnt = strtok(options.extra_mounts, ",");
+        char *mnt = strtok(options.extra_mounts, " ");
         while (mnt) {
           const char *source = strsep(&mnt, ":");
           const char *target = strsep(&mnt, ":");

--- a/src/fs.c
+++ b/src/fs.c
@@ -106,13 +106,13 @@ void setup_filesystems()
     // An example mount specification looks like:
     //    /dev/mmcblk0p4:/mnt:vfat::utf8
     if (options.extra_mounts) {
-        char *mounts = strtok(options.extra_mounts, ",");
-        while (mounts) {
-          const char *source = strsep(&temp, ":");
-          const char *target = strsep(&temp, ":");
-          const char *filesystemtype = strsep(&temp, ":");
-          char *mountflags = strsep(&temp, ":");
-          const char *data = strsep(&temp, ":");
+        char *mount = strtok(options.extra_mounts, ",");
+        while (mount) {
+          const char *source = strsep(&mount, ":");
+          const char *target = strsep(&mount, ":");
+          const char *filesystemtype = strsep(&mount, ":");
+          char *mountflags = strsep(&mount, ":");
+          const char *data = strsep(&mount, ":");
 
           if (source && target && filesystemtype && mountflags && data) {
   #ifndef UNITTEST

--- a/src/fs.c
+++ b/src/fs.c
@@ -106,24 +106,26 @@ void setup_filesystems()
     // An example mount specification looks like:
     //    /dev/mmcblk0p4:/mnt:vfat::utf8
     if (options.extra_mounts) {
-        char *temp = options.extra_mounts;
-        const char *source = strsep(&temp, ":");
-        const char *target = strsep(&temp, ":");
-        const char *filesystemtype = strsep(&temp, ":");
-        char *mountflags = strsep(&temp, ":");
-        const char *data = strsep(&temp, ":");
+        char *mounts = strtok(options.extra_mounts, ",");
+        while (mounts) {
+          const char *source = strsep(&temp, ":");
+          const char *target = strsep(&temp, ":");
+          const char *filesystemtype = strsep(&temp, ":");
+          char *mountflags = strsep(&temp, ":");
+          const char *data = strsep(&temp, ":");
 
-        if (source && target && filesystemtype && mountflags && data) {
-#ifndef UNITTEST
-            unsigned long imountflags =
-                    str_to_mountflags(mountflags);
-            if (mount(source, target, filesystemtype, imountflags, data) < 0)
-                warn("Cannot mount %s at %s: %s", source, target, strerror(errno));
-#else
-            warn("Cannot mount %s at %s: %s", source, target, "regression test");
-#endif
-        } else {
-            warn("Invalid parameter to -m. Expecting 5 colon-separated fields");
+          if (source && target && filesystemtype && mountflags && data) {
+  #ifndef UNITTEST
+              unsigned long imountflags =
+                      str_to_mountflags(mountflags);
+              if (mount(source, target, filesystemtype, imountflags, data) < 0)
+                  warn("Cannot mount %s at %s: %s", source, target, strerror(errno));
+  #else
+              warn("Cannot mount %s at %s: %s", source, target, "regression test");
+  #endif
+          } else {
+              warn("Invalid parameter to -m. Expecting 5 colon-separated fields");
+          }
         }
     }
 }

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -11,7 +11,7 @@ EOF
 
 $CAT >$EXPECTED <<EOF
 erlinit: cmdline argc=4, merged argc=4
-erlinit: cmdline argc=5, merged argc=5
+erlinit: cmdline argc=4, merged argc=4
 erlinit: merged argv[0]=/sbin/erlinit
 erlinit: merged argv[1]=-v
 erlinit: merged argv[2]=--mount

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -10,8 +10,8 @@ $CAT >$CMDLINE_FILE <<EOF
 EOF
 
 $CAT >$EXPECTED <<EOF
-erlinit: cmdline argc=5, merged argc=5
 erlinit: cmdline argc=4, merged argc=4
+erlinit: cmdline argc=5, merged argc=5
 erlinit: merged argv[0]=/sbin/erlinit
 erlinit: merged argv[1]=-v
 erlinit: merged argv[2]=--mount

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -6,17 +6,15 @@
 #
 
 $CAT >$CMDLINE_FILE <<EOF
--v --mount /dev/mmcblk0p3:/root:vfat:: /dev/mmcblk0p4:/mnt:vfat::
+-v --mount "/dev/mmcblk0p3:/root:vfat:: /dev/mmcblk0p4:/mnt:vfat::"
 EOF
 
 $CAT >$EXPECTED <<EOF
 erlinit: cmdline argc=4, merged argc=4
-erlinit: cmdline argc=4, merged argc=4
 erlinit: merged argv[0]=/sbin/erlinit
 erlinit: merged argv[1]=-v
 erlinit: merged argv[2]=--mount
-erlinit: merged argv[3]=/dev/mmcblk0p3:/root:vfat::
-erlinit: merged argv[4]=/dev/mmcblk0p4:/mnt:vfat::
+erlinit: merged argv[3]="/dev/mmcblk0p3:/root:vfat:: /dev/mmcblk0p4:/mnt:vfat::"
 erlinit: set_ctty
 erlinit: Cannot mount /dev/mmcblk0p3 at /root: regression test
 erlinit: find_erts_directory

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -6,7 +6,7 @@
 #
 
 $CAT >$CMDLINE_FILE <<EOF
--v --mount /dev/mmcblk0p3:/root:vfat::
+-v --mount /dev/mmcblk0p3:/root:vfat:: /dev/mmcblk0p4:/mnt:vfat:: 
 EOF
 
 $CAT >$EXPECTED <<EOF

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -16,6 +16,7 @@ erlinit: merged argv[0]=/sbin/erlinit
 erlinit: merged argv[1]=-v
 erlinit: merged argv[2]=--mount
 erlinit: merged argv[3]=/dev/mmcblk0p3:/root:vfat::
+erlinit: merged argv[4]=/dev/mmcblk0p4:/mnt:vfat::
 erlinit: set_ctty
 erlinit: Cannot mount /dev/mmcblk0p3 at /root: regression test
 erlinit: find_erts_directory

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -6,10 +6,11 @@
 #
 
 $CAT >$CMDLINE_FILE <<EOF
--v --mount /dev/mmcblk0p3:/root:vfat:: /dev/mmcblk0p4:/mnt:vfat:: 
+-v --mount /dev/mmcblk0p3:/root:vfat:: /dev/mmcblk0p4:/mnt:vfat::
 EOF
 
 $CAT >$EXPECTED <<EOF
+erlinit: cmdline argc=5, merged argc=5
 erlinit: cmdline argc=4, merged argc=4
 erlinit: merged argv[0]=/sbin/erlinit
 erlinit: merged argv[1]=-v


### PR DESCRIPTION
Nerves should allow the user to define multiple file systems they wish to mount.
When defining extra mounts, -m will only handle a single set of configuration to be passed. 