### PR TITLE
Add graceful shutdown timeout flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.1.0-dev
+
+  * New features
+    * Add graceful-shutdown-timeout option to specify longer or shorter
+      timeouts for waiting for the Erlang VM to exit gracefully.
+
 ## v1.0.1
 
   * Fixes

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ The following lists the options:
     --gid <id>
         Run the Erlang VM under the specified group ID
 
+    --graceful-shutdown-timeout <milliseconds>
+        After the application signals that it wants to reboot, poweroff, or halt,
+        wait this many milliseconds for it to cleanup and exit.
+
     -h, --hang-on-exit
         Hang the system if Erlang exits. The default is to reboot.
 

--- a/src/erlinit.h
+++ b/src/erlinit.h
@@ -74,6 +74,7 @@ struct erlinit_options {
     char *working_directory;
     int uid;
     int gid;
+    int graceful_shutdown_timeout_ms;
 };
 
 extern struct erlinit_options options;

--- a/src/options.c
+++ b/src/options.c
@@ -51,7 +51,8 @@ struct erlinit_options options = {
     .boot_path = NULL,
     .working_directory = NULL,
     .gid = 0,
-    .uid = 0
+    .uid = 0,
+    .graceful_shutdown_timeout_ms = 10000,
 };
 
 static struct option long_options[] = {
@@ -77,6 +78,7 @@ static struct option long_options[] = {
     {"uid", required_argument, 0, '^' },
     {"gid", required_argument, 0, '&' },
     {"pre-run-exec", required_argument, 0, '*' },
+    {"graceful-shutdown-timeout", required_argument, 0, '(' },
     {0,     0,      0, 0 }
 };
 
@@ -170,6 +172,9 @@ void parse_args(int argc, char *argv[])
             break;
         case '@': // --working_directory /root
             SET_STRING_OPTION(options.working_directory);
+            break;
+        case '(': // --graceful-shutdown-timeout 10000
+            options.graceful_shutdown_timeout_ms = strtol(optarg, NULL, 0);
             break;
         default:
             // getopt prints a warning, so we don't have to

--- a/tests/031_graceful_reboot
+++ b/tests/031_graceful_reboot
@@ -48,7 +48,7 @@ erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
 erlinit: Launching erl...
 erlexec is sending signal to reboot
 erlinit: sigterm -> reboot
-erlinit: waiting for graceful shutdown
+erlinit: waiting 10000 ms for graceful shutdown
 erlinit: graceful shutdown detected
 erlinit: kill_all
 erlinit: unmount_all

--- a/tests/032_graceful_poweroff
+++ b/tests/032_graceful_poweroff
@@ -48,7 +48,7 @@ erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
 erlinit: Launching erl...
 erlexec is sending signal to poweroff
 erlinit: sigusr2 -> poweroff
-erlinit: waiting for graceful shutdown
+erlinit: waiting 10000 ms for graceful shutdown
 erlinit: graceful shutdown detected
 erlinit: kill_all
 erlinit: unmount_all

--- a/tests/033_ungraceful_halt
+++ b/tests/033_ungraceful_halt
@@ -48,7 +48,7 @@ erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
 erlinit: Launching erl...
 erlexec is sending signal to halt
 erlinit: sigpwr|sigusr1 -> halt
-erlinit: waiting for graceful shutdown
+erlinit: waiting 10000 ms for graceful shutdown
 erlinit: Wait for Erlang VM to exit gracefully expired. Killing...
 erlinit: kill_all
 erlinit: unmount_all

--- a/tests/037_graceful_timeout
+++ b/tests/037_graceful_timeout
@@ -5,7 +5,7 @@
 #
 
 $CAT >$CMDLINE_FILE <<EOF
--v
+-v --graceful-shutdown-timeout 15000
 EOF
 
 RELEASE_PATH=$WORK/srv/erlang/releases/0.0.1
@@ -16,9 +16,11 @@ $TOUCH $RELEASE_PATH/vm.args
 $LN -sf $FAKE_ERLEXEC.halt $FAKE_ERTS_DIR/bin/erlexec
 
 $CAT >$EXPECTED <<EOF
-erlinit: cmdline argc=2, merged argc=2
+erlinit: cmdline argc=4, merged argc=4
 erlinit: merged argv[0]=/sbin/erlinit
 erlinit: merged argv[1]=-v
+erlinit: merged argv[2]=--graceful-shutdown-timeout
+erlinit: merged argv[3]=15000
 erlinit: set_ctty
 erlinit: find_erts_directory
 erlinit: find_release
@@ -48,7 +50,7 @@ erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
 erlinit: Launching erl...
 erlexec is sending signal to halt
 erlinit: sigpwr|sigusr1 -> halt
-erlinit: waiting 10000 ms for graceful shutdown
+erlinit: waiting 15000 ms for graceful shutdown
 erlinit: graceful shutdown detected
 erlinit: kill_all
 erlinit: unmount_all


### PR DESCRIPTION
This set of changes lets a user specify in the `erlinit.conf` a longer or shorter timeout for erlinit to use when waiting for the Erlang VM to exit. The reason for this change is that the default 10 second timeout seems like it might be on the short side if an app causes  a lot of data to be sync'd to disk. I'd like people to be able to experiment with making this longer before filing issues against `erlinit`.