### PR TITLE
 Add support for Elixir's consolidated directory

### DIFF
--- a/tests/038_consolidated_protocols
+++ b/tests/038_consolidated_protocols
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+#
+# Test that changing the working directory works
+#
+
+$CAT >$CMDLINE_FILE <<EOF
+-v
+EOF
+
+RELEASE_PATH=$WORK/srv/erlang/releases/0.0.1
+LIB_PATH=$WORK/srv/erlang/lib/test-0.0.1
+
+$MKDIR -p $RELEASE_PATH
+$TOUCH $RELEASE_PATH/test.boot
+$TOUCH $RELEASE_PATH/sys.config
+$TOUCH $RELEASE_PATH/vm.args
+$MKDIR -p $LIB_PATH/consolidated
+$TOUCH $LIB_PATH/consolidated/foo.beam
+
+$CAT >$EXPECTED <<EOF
+erlinit: cmdline argc=2, merged argc=2
+erlinit: merged argv[0]=/sbin/erlinit
+erlinit: merged argv[1]=-v
+erlinit: set_ctty
+erlinit: find_erts_directory
+erlinit: find_release
+erlinit: /srv/erlang/releases/start_erl.data not found.
+erlinit: Using release in /srv/erlang/releases/0.0.1.
+erlinit: find_sys_config
+erlinit: find_vm_args
+erlinit: find_boot_path
+erlinit: setup_environment
+erlinit: setup_networking
+erlinit: configure_hostname
+erlinit: /etc/hostname not found
+erlinit: Env: 'HOME=/root'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/srv/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erl'
+erlinit: Arg: 'erlexec'
+erlinit: Arg: '-pa'
+erlinit: Arg: '/srv/erlang/lib/test-0.0.1/consolidated'
+erlinit: Arg: '-config'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/sys.config'
+erlinit: Arg: '-boot'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
+erlinit: Arg: '-args_file'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Launching erl...
+Hello from erlexec
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: unmount_all
+EOF

--- a/tests/039_multi_consolidated
+++ b/tests/039_multi_consolidated
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+#
+# Test that changing the working directory works
+#
+
+$CAT >$CMDLINE_FILE <<EOF
+-v
+EOF
+
+RELEASE_PATH=$WORK/srv/erlang/releases/0.0.1
+LIB_PATH=$WORK/srv/erlang/lib/test-0.0.1
+LIB_PATH2=$WORK/srv/erlang/lib/zzz-0.0.1
+
+$MKDIR -p $RELEASE_PATH
+$TOUCH $RELEASE_PATH/test.boot
+$TOUCH $RELEASE_PATH/sys.config
+$TOUCH $RELEASE_PATH/vm.args
+$MKDIR -p $LIB_PATH/consolidated
+$TOUCH $LIB_PATH/consolidated/foo.beam
+$MKDIR -p $LIB_PATH2/consolidated
+$TOUCH $LIB_PATH2/consolidated/foo.beam
+
+$CAT >$EXPECTED <<EOF
+erlinit: cmdline argc=2, merged argc=2
+erlinit: merged argv[0]=/sbin/erlinit
+erlinit: merged argv[1]=-v
+erlinit: set_ctty
+erlinit: find_erts_directory
+erlinit: find_release
+erlinit: /srv/erlang/releases/start_erl.data not found.
+erlinit: Using release in /srv/erlang/releases/0.0.1.
+erlinit: find_sys_config
+erlinit: find_vm_args
+erlinit: find_boot_path
+erlinit: More than one consolidated directory found. Using '/srv/erlang/lib/test-0.0.1/consolidated'
+erlinit: setup_environment
+erlinit: setup_networking
+erlinit: configure_hostname
+erlinit: /etc/hostname not found
+erlinit: Env: 'HOME=/root'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/srv/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erl'
+erlinit: Arg: 'erlexec'
+erlinit: Arg: '-pa'
+erlinit: Arg: '/srv/erlang/lib/test-0.0.1/consolidated'
+erlinit: Arg: '-config'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/sys.config'
+erlinit: Arg: '-boot'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
+erlinit: Arg: '-args_file'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Launching erl...
+Hello from erlexec
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: unmount_all
+EOF


### PR DESCRIPTION
This is needed to significantly speed up use of Elixir Protocols. Only
one directory is currently supported since that's also that should
exist. If more than one exists, we'll have to revisit since it's not
clear to me what order they should be added to Erlang's load path and
how we'd know.