### PR TITLE
Add /dev/rootdisk* helper symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,18 @@ hostname. The configuration would look like:
 In theory, the `getmyhostname` program could read an EEPROM or some file on a
 writable partition to return the hostname.
 
+## Root disk naming
+
+If you have multiple memory cards, SSDs, or other devices connected, it's
+possible that Linux will enumerate those devices in a nondeterministic order.
+This can be mitigated by using `udev` to populate the `/dev/disks/by-*`
+directories, but even this can be inconvenient when you just want to refer to
+the drive that provides the root filesystem. To address this, `erlinit` creates
+`/dev/rootdisk0`, `/dev/rootdisk1`, etc. and symlinks them to the expected
+devices. For example, if your root file system is on `/dev/mmcblk0p1`, you'll
+get a symlink from `/dev/rootdisk1` to `/dev/mmcblk0p1` and similar files for
+each partition. The whole disk will be `/dev/rootdisk0`.
+
 ## Chaining programs
 
 It's possible for `erlinit` to run a program that launches `erlexec` so that

--- a/src/erlinit.c
+++ b/src/erlinit.c
@@ -543,7 +543,7 @@ static void drop_privileges()
 
 static void child()
 {
-    setup_filesystems();
+    mount_filesystems();
 
     // Locate everything needed to configure the environment
     // and pass to erlexec.

--- a/src/erlinit.c
+++ b/src/erlinit.c
@@ -829,6 +829,10 @@ int main(int argc, char *argv[])
     // Mount /dev, /proc and /sys
     setup_pseudo_filesystems();
 
+    // Create symlinks for partitions on the drive containing the
+    // root filesystem.
+    create_rootdisk_symlinks();
+
     // Fix the terminal settings so output goes to the right
     // terminal and the CTRL keys work in the shell..
     set_ctty();

--- a/src/erlinit.h
+++ b/src/erlinit.h
@@ -99,7 +99,7 @@ void setup_networking();
 
 // Filesystems
 void setup_pseudo_filesystems();
-void setup_filesystems();
+void mount_filesystems();
 void unmount_all();
 
 // Terminal

--- a/src/erlinit.h
+++ b/src/erlinit.h
@@ -99,6 +99,7 @@ void setup_networking();
 
 // Filesystems
 void setup_pseudo_filesystems();
+void create_rootdisk_symlinks();
 void mount_filesystems();
 void unmount_all();
 

--- a/src/fs.c
+++ b/src/fs.c
@@ -85,7 +85,7 @@ void setup_pseudo_filesystems()
 #endif
 }
 
-void setup_filesystems()
+void mount_filesystems()
 {
 #ifndef UNITTEST
     // Mount /tmp and /run since they're almost always needed and it's

--- a/tests/run_tests_impl.sh
+++ b/tests/run_tests_impl.sh
@@ -56,6 +56,7 @@ run() {
     $MKDIR -p $WORK/tmp
     $MKDIR -p $WORK/usr/bin
     $LN -s $ECHO $WORK/$ECHO
+    $LN -s $LS $WORK/$LS
     $LN -s $SH $WORK/$SH
     $LN -s $CAT $WORK/$CAT
     $LN -s $CUT $WORK/$CUT


### PR DESCRIPTION
This is needed to sanely refer to the disk that provides the root
filesystem. Without it, hacks are needed or you need to start udevd to
create the /dev/disk/by-* directories and symlinks. None of these are
particularly convenient since the files aren't available as early on in
bootup as what erlinit can do.