### PR TITLE
Advance the clock if it's before the build timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION=1.3.1
 CFLAGS+=-Wall -Wextra -O2
 
 # _GNU_SOURCE is for asprintf
-EXTRA_CFLAGS= -D_GNU_SOURCE -DPROGRAM_VERSION=$(VERSION)
+EXTRA_CFLAGS= -D_GNU_SOURCE -DPROGRAM_VERSION=$(VERSION) -DBUILD_TIME=$(shell date +%s)
 
 erlinit: $(wildcard src/*.c)
 	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $^

--- a/README.md
+++ b/README.md
@@ -125,11 +125,14 @@ The following lists the options:
         Print out when erlinit starts and when it launches Erlang (for
         benchmarking)
 
-    -v, --verbose
-        Enable verbose prints
-
     --uid <id>
         Run the Erlang VM under the specified user ID
+
+    --update-clock
+        Force the system clock to at least the build date/time of erlinit.
+
+    -v, --verbose
+        Enable verbose prints
 
     --warn-unused-tty
         Print a message on ttys receiving kernel logs, but not an Erlang console
@@ -281,3 +284,23 @@ to reduce privilege by specifying the `--uid` and `--gid` options. Before doing
 this, make sure that your embedded Erlang/OTP application can support this. When
 dealing with hardware, it is quite easy to run into situations requiring elevated
 privileges.
+
+## Clocks
+
+If you're running on a system without a real-time clock, the clock will report that
+it's 1970. Even if you have a real-time clock, a failure of the battery could still
+cause it to show a date in the 1980s or 1990s. `erlinit` isn't smart enough to fix
+this, but it can set a lower bound for the clock based on its build timestamp.
+Specify the `--update-clock` option to enable this. Additionally, this lower bound
+is set very early on in the boot process so nothing besides `erlinit` should see
+a decade's old time.
+
+This option has the following caveats:
+
+1. Some projects have chosen to use the date to check whether NTP has synchronized
+   the clock yet. If you are a person who did this, please consider a more direct
+   route of checking NTP's synchronization status.
+2. Look into what `fake-hwclock` does if you need something better.
+3. If using this to guarantee a minimum timestamp so that SSL certificates work, be
+   sure that the SSL certificates don't expire before the next firmware update.
+   (Not that you don't have to do that anyway, but just a friendly reminder)

--- a/src/erlinit.h
+++ b/src/erlinit.h
@@ -75,6 +75,7 @@ struct erlinit_options {
     int uid;
     int gid;
     int graceful_shutdown_timeout_ms;
+    int update_clock;
 };
 
 extern struct erlinit_options options;

--- a/src/fs.c
+++ b/src/fs.c
@@ -57,6 +57,8 @@ static unsigned long str_to_mountflags(char *s)
             flags |= MS_NOSUID;
         else if (strcmp(flag, "ro") == 0)
             flags |= MS_RDONLY;
+        else if (strcmp(flag, "rw") == 0)
+            flags &= MS_RDONLY;
         else if (strcmp(flag, "relatime") == 0)
             flags |= MS_RELATIME;
         else if (strcmp(flag, "silent") == 0)

--- a/src/fs.c
+++ b/src/fs.c
@@ -192,8 +192,12 @@ void mount_filesystems()
 
         if (source && target && filesystemtype && mountflags && data) {
 #ifndef UNITTEST
-            unsigned long imountflags =
-                    str_to_mountflags(mountflags);
+            // Try to mkdir the target just in case the final path entry does
+            // not exist. This is a convenience for mounting in filesystems
+            // created by the kernel like /dev and /sys/fs/*.
+            (void) mkdir(target, 0755);
+
+            unsigned long imountflags = str_to_mountflags(mountflags);
             if (mount(source, target, filesystemtype, imountflags, data) < 0)
                 warn("Cannot mount %s at %s: %s", source, target, strerror(errno));
 #else

--- a/src/fs.c
+++ b/src/fs.c
@@ -80,13 +80,13 @@ void setup_pseudo_filesystems()
 {
     // This only works in the real environment.
 #ifndef UNITTEST
-    OK_OR_WARN(mount("", "/proc", "proc", 0, NULL), "Cannot mount /proc");
-    OK_OR_WARN(mount("", "/sys", "sysfs", 0, NULL), "Cannot mount /sys");
+    OK_OR_WARN(mount("", "/proc", "proc", MS_NOEXEC | MS_NOSUID | MS_NODEV, NULL), "Cannot mount /proc");
+    OK_OR_WARN(mount("", "/sys", "sysfs", MS_NOEXEC | MS_NOSUID | MS_NODEV, NULL), "Cannot mount /sys");
 
     // /dev should be automatically created/mounted by Linux
     OK_OR_WARN(mkdir("/dev/pts", 0755), "Cannot create /dev/pts");
     OK_OR_WARN(mkdir("/dev/shm", 0755), "Cannot create /dev/shm");
-    OK_OR_WARN(mount("", "/dev/pts", "devpts", 0, "gid=5,mode=620"), "Cannot mount /dev/pts");
+    OK_OR_WARN(mount("", "/dev/pts", "devpts", MS_NOEXEC | MS_NOSUID, "gid=5,mode=620"), "Cannot mount /dev/pts");
 #endif
 }
 
@@ -166,11 +166,11 @@ void mount_filesystems()
 #ifndef UNITTEST
     // Mount /tmp and /run since they're almost always needed and it's
     // not easy to do it at the right time in Erlang.
-    if (mount("", "/tmp", "tmpfs", 0, "mode=1777,size=10%") < 0)
+    if (mount("", "/tmp", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV, "mode=1777,size=10%") < 0)
         warn("Could not mount tmpfs in /tmp: %s\r\n"
              "Check that tmpfs support is enabled in the kernel config.", strerror(errno));
 
-    if (mount("", "/run", "tmpfs", MS_NOSUID | MS_NODEV, "mode=0755,size=5%") < 0)
+    if (mount("", "/run", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV, "mode=0755,size=5%") < 0)
         warn("Could not mount tmpfs in /run: %s", strerror(errno));
 #endif
 

--- a/src/options.c
+++ b/src/options.c
@@ -51,6 +51,7 @@ struct erlinit_options options = {
     .gid = 0,
     .uid = 0,
     .graceful_shutdown_timeout_ms = 10000,
+    .update_clock = 0
 };
 
 static struct option long_options[] = {
@@ -77,6 +78,7 @@ static struct option long_options[] = {
     {"gid", required_argument, 0, '&' },
     {"pre-run-exec", required_argument, 0, '*' },
     {"graceful-shutdown-timeout", required_argument, 0, '(' },
+    {"update-clock", no_argument, 0, ')'},
     {0,     0,      0, 0 }
 };
 
@@ -173,6 +175,9 @@ void parse_args(int argc, char *argv[])
             break;
         case '(': // --graceful-shutdown-timeout 10000
             options.graceful_shutdown_timeout_ms = strtol(optarg, NULL, 0);
+            break;
+        case ')': // --update-clock
+            options.update_clock = 1;
             break;
         default:
             // getopt prints a warning, so we don't have to

--- a/tests/040_update_clock
+++ b/tests/040_update_clock
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+#
+# Test that specifying --update-clock in the config file is
+# detected.
+#
+
+$CAT >$CONFIG <<EOF
+-v
+--update-clock
+EOF
+
+$CAT >$EXPECTED <<EOF
+erlinit: cmdline argc=1, merged argc=3
+erlinit: merged argv[0]=/sbin/erlinit
+erlinit: merged argv[1]=-v
+erlinit: merged argv[2]=--update-clock
+erlinit: set_ctty
+erlinit: checking that the clock is after the build timestamp
+erlinit: find_erts_directory
+erlinit: find_release
+erlinit: No release found in /srv/erlang.
+erlinit: setup_environment
+erlinit: setup_networking
+erlinit: configure_hostname
+erlinit: /etc/hostname not found
+erlinit: Env: 'HOME=/root'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erl'
+erlinit: Arg: 'erlexec'
+erlinit: Launching erl...
+Hello from erlexec
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: unmount_all
+EOF


### PR DESCRIPTION
This brings us out of the 1970s and more importantly, makes some SSL
certs work without waiting on NTP.