### PR TITLE
Filesystem mount updates

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -57,6 +57,8 @@ static unsigned long str_to_mountflags(char *s)
             flags |= MS_NOSUID;
         else if (strcmp(flag, "ro") == 0)
             flags |= MS_RDONLY;
+        else if (strcmp(flag, "rw") == 0)
+            flags &= MS_RDONLY;
         else if (strcmp(flag, "relatime") == 0)
             flags |= MS_RELATIME;
         else if (strcmp(flag, "silent") == 0)

--- a/src/fs.c
+++ b/src/fs.c
@@ -192,8 +192,12 @@ void mount_filesystems()
 
         if (source && target && filesystemtype && mountflags && data) {
 #ifndef UNITTEST
-            unsigned long imountflags =
-                    str_to_mountflags(mountflags);
+            // Try to mkdir the target just in case the final path entry does
+            // not exist. This is a convenience for mounting in filesystems
+            // created by the kernel like /dev and /sys/fs/*.
+            (void) mkdir(target, 0755);
+
+            unsigned long imountflags = str_to_mountflags(mountflags);
             if (mount(source, target, filesystemtype, imountflags, data) < 0)
                 warn("Cannot mount %s at %s: %s", source, target, strerror(errno));
 #else

--- a/src/fs.c
+++ b/src/fs.c
@@ -80,13 +80,13 @@ void setup_pseudo_filesystems()
 {
     // This only works in the real environment.
 #ifndef UNITTEST
-    OK_OR_WARN(mount("", "/proc", "proc", 0, NULL), "Cannot mount /proc");
-    OK_OR_WARN(mount("", "/sys", "sysfs", 0, NULL), "Cannot mount /sys");
+    OK_OR_WARN(mount("", "/proc", "proc", MS_NOEXEC | MS_NOSUID | MS_NODEV, NULL), "Cannot mount /proc");
+    OK_OR_WARN(mount("", "/sys", "sysfs", MS_NOEXEC | MS_NOSUID | MS_NODEV, NULL), "Cannot mount /sys");
 
     // /dev should be automatically created/mounted by Linux
     OK_OR_WARN(mkdir("/dev/pts", 0755), "Cannot create /dev/pts");
     OK_OR_WARN(mkdir("/dev/shm", 0755), "Cannot create /dev/shm");
-    OK_OR_WARN(mount("", "/dev/pts", "devpts", 0, "gid=5,mode=620"), "Cannot mount /dev/pts");
+    OK_OR_WARN(mount("", "/dev/pts", "devpts", MS_NOEXEC | MS_NOSUID, "gid=5,mode=620"), "Cannot mount /dev/pts");
 #endif
 }
 
@@ -166,11 +166,11 @@ void mount_filesystems()
 #ifndef UNITTEST
     // Mount /tmp and /run since they're almost always needed and it's
     // not easy to do it at the right time in Erlang.
-    if (mount("", "/tmp", "tmpfs", 0, "mode=1777,size=10%") < 0)
+    if (mount("", "/tmp", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV, "mode=1777,size=10%") < 0)
         warn("Could not mount tmpfs in /tmp: %s\r\n"
              "Check that tmpfs support is enabled in the kernel config.", strerror(errno));
 
-    if (mount("", "/run", "tmpfs", MS_NOSUID | MS_NODEV, "mode=0755,size=5%") < 0)
+    if (mount("", "/run", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV, "mode=0755,size=5%") < 0)
         warn("Could not mount tmpfs in /run: %s", strerror(errno));
 #endif
 


### PR DESCRIPTION
See the commits for changes. The most important change here was the mkdir convenience method needed to use cgroups more easily with Nerves. The other change to lock down the tmpfs mounts seemed prudent. A paranoid person could lock down much more and I'm not intending to do that as part of this effort.