### PR TITLE
Protect against whitespace in the hostname

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -119,6 +119,19 @@ static void trim_whitespace(char *s)
     s[len] = 0;
 }
 
+static void kill_whitespace(char *s)
+{
+    // This function trims whitespace off the front and back, and if
+    // there's any whitespace in the middle, it truncates the string there.
+    trim_whitespace(s);
+    while (*s) {
+        if (isspace(*s))
+            *s = '\0';
+        else
+            s++;
+    }
+}
+
 static void configure_hostname()
 {
     debug("configure_hostname");
@@ -127,10 +140,12 @@ static void configure_hostname()
     if (options.hostname_pattern) {
         // Set the hostname based on a pattern
         char unique_id[64] = "xxxxxxxx";
-        if (options.uniqueid_exec)
+        if (options.uniqueid_exec) {
             system_cmd(options.uniqueid_exec, unique_id, sizeof(unique_id));
-
+            kill_whitespace(unique_id);
+        }
         sprintf(hostname, options.hostname_pattern, unique_id);
+        kill_whitespace(hostname);
     } else {
         // Set the hostname from /etc/hostname
         FILE *fp = fopen("/etc/hostname", "r");

--- a/tests/041_uniqueid_whitespace
+++ b/tests/041_uniqueid_whitespace
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+#
+# Test that calling out to a unique id generator does the right thing
+#
+
+$CAT >$CONFIG <<EOF
+-v
+
+# Specify a hostname pattern that has a unique id part
+--hostname-pattern nerves-%s
+
+# Call out to a dummy unique id generator
+--uniqueid-exec "/usr/bin/make-unique-id"
+EOF
+
+$CAT >$WORK/usr/bin/make-unique-id <<EOF
+#!/bin/sh
+
+echo "  4\n888888888\n\n"
+EOF
+
+$CAT >$EXPECTED <<EOF
+erlinit: cmdline argc=1, merged argc=6
+erlinit: merged argv[0]=/sbin/erlinit
+erlinit: merged argv[1]=-v
+erlinit: merged argv[2]=--hostname-pattern
+erlinit: merged argv[3]=nerves-%s
+erlinit: merged argv[4]=--uniqueid-exec
+erlinit: merged argv[5]=/usr/bin/make-unique-id
+erlinit: set_ctty
+erlinit: find_erts_directory
+erlinit: find_release
+erlinit: No release found in /srv/erlang.
+erlinit: setup_environment
+erlinit: setup_networking
+erlinit: configure_hostname
+erlinit: system_cmd '/usr/bin/make-unique-id'
+erlinit: Hostname: nerves-4
+erlinit: Env: 'HOME=/root'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erl'
+erlinit: Arg: 'erlexec'
+erlinit: Launching erl...
+Hello from erlexec
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: unmount_all
+EOF


### PR DESCRIPTION
This bulletproofs erlinit from setting the hostname to values that have
newlines or spaces in them due to mistakes in the erlinit config.