### PR TITLE
Restore sigmask for child proceses

### DIFF
--- a/src/erlinit.c
+++ b/src/erlinit.c
@@ -761,12 +761,16 @@ static void fork_and_wait(int *is_intentional_exit, int *desired_reboot_cmd)
     // Block signals from the child process so that they're
     // handled by sigtimedwait.
     if (sigprocmask(SIG_BLOCK, &mask, &orig_mask) < 0)
-        fatal("sigprocmask failed");
+        fatal("sigprocmask(SIG_BLOCK) failed");
 
     // Do most of the work in a child process so that if it
     // crashes, we can handle the crash.
     pid_t pid = fork();
     if (pid == 0) {
+        // Unblock signals in the child
+        if (sigprocmask(SIG_SETMASK, &orig_mask, NULL) < 0)
+            fatal("sigprocmask(SIG_SETMASK) failed");
+
         child();
         exit(1);
     }


### PR DESCRIPTION
To prevent a race condition, erlinit masks a set of signals until it's
ready to handle them. The signal mask gets inherited to child processes
and this may not be what they want or expect. This change restores the
signal mask to its original value.

This change fixes an issue where the application being launched by
erlinit was waiting for a SIGCHLD, but never received it since it was
masked.