### PR TITLE
Use erts version as specified by start_erl.data

### DIFF
--- a/tests/001_cmdline_verbose
+++ b/tests/001_cmdline_verbose
@@ -21,9 +21,9 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/002_config_verbose
+++ b/tests/002_config_verbose
@@ -21,9 +21,9 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/003_run_release
+++ b/tests/003_run_release
@@ -27,13 +27,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/004_run_deep_release
+++ b/tests/004_run_deep_release
@@ -28,13 +28,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/myrelease/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/myrelease/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/005_run_strace
+++ b/tests/005_run_strace
@@ -33,9 +33,9 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/006_env
+++ b/tests/006_env
@@ -23,9 +23,9 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/007_multi_release_paths
+++ b/tests/007_multi_release_paths
@@ -29,7 +29,6 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /mnt/anotherplace.
 erlinit: /srv/erlang/releases/start_erl.data not found.
@@ -37,6 +36,7 @@ erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/008_cmdline_verbose2
+++ b/tests/008_cmdline_verbose2
@@ -21,9 +21,9 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -26,9 +26,9 @@ fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
 fixture: mkdir("/root", 755)
 fixture: mount("/dev/mmcblk0p3", "/root", "vfat", 0, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/011_etc_hostname
+++ b/tests/011_etc_hostname
@@ -25,9 +25,9 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/012_bad_option
+++ b/tests/012_bad_option
@@ -23,9 +23,9 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/013_bad_option2
+++ b/tests/013_bad_option2
@@ -23,9 +23,9 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/014_tty_warning
+++ b/tests/014_tty_warning
@@ -36,9 +36,9 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/015_multi_mount
+++ b/tests/015_multi_mount
@@ -30,9 +30,9 @@ fixture: mkdir("/root", 755)
 fixture: mount("/dev/mmcblk0p3", "/root", "vfat", 0, data)
 fixture: mkdir("/mnt", 755)
 fixture: mount("/dev/mmcblk0p4", "/mnt", "ext4", 0, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/016_erlexec_boot_arg
+++ b/tests/016_erlexec_boot_arg
@@ -23,9 +23,9 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/017_erlexec_boot_arg_file
+++ b/tests/017_erlexec_boot_arg_file
@@ -23,9 +23,9 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/018_run_on_exit
+++ b/tests/018_run_on_exit
@@ -36,13 +36,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/019_uid_and_gid
+++ b/tests/019_uid_and_gid
@@ -26,9 +26,9 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/020_pre_run_exec
+++ b/tests/020_pre_run_exec
@@ -36,13 +36,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/021_multi_boot_script
+++ b/tests/021_multi_boot_script
@@ -30,7 +30,6 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
@@ -38,6 +37,7 @@ erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
 erlinit: Found more than one boot file. Using a.boot.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/022_pick_boot_script
+++ b/tests/022_pick_boot_script
@@ -34,13 +34,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/023_pick_boot_script2
+++ b/tests/023_pick_boot_script2
@@ -34,13 +34,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/024_pick_missing_boot_script
+++ b/tests/024_pick_missing_boot_script
@@ -33,7 +33,6 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
@@ -42,6 +41,7 @@ erlinit: find_vm_args
 erlinit: find_boot_path
 erlinit: Specified boot file 'missing_boot_script' not found. Auto-detecting.
 erlinit: Found more than one boot file. Using a.boot.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/025_start_erl_data
+++ b/tests/025_start_erl_data
@@ -23,7 +23,7 @@ for RPATH in $RELEASE_PATH1 $RELEASE_PATH2 $RELEASE_PATH3; do
 done
 
 cat >$WORK/srv/erlang/releases/start_erl.data <<EOF
-8.3 0.0.2
+6.0 0.0.2
 EOF
 
 cat >$EXPECTED <<EOF
@@ -39,13 +39,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: Using release in /srv/erlang/releases/0.0.2.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
 erlinit: Found more than one boot file. Using a.boot.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/026_bad_start_erl_data
+++ b/tests/026_bad_start_erl_data
@@ -40,7 +40,6 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: start_erl.data specifies 0.0.212903847012, but /srv/erlang/releases/0.0.212903847012 isn't a directory
 erlinit: Using release in /srv/erlang/releases/0.0.3.
@@ -48,6 +47,8 @@ erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
 erlinit: Found more than one boot file. Using a.boot.
+erlinit: find_erts_directory
+erlinit: start_erl.data specifies erts-8.31234500320020, but it wasn't found! Looking for any erts version
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/027_bad_start_erl_data2
+++ b/tests/027_bad_start_erl_data2
@@ -40,7 +40,6 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data doesn't contain expected contents. Skipping.
 erlinit: Using release in /srv/erlang/releases/0.0.3.
@@ -48,6 +47,7 @@ erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
 erlinit: Found more than one boot file. Using a.boot.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/028_boot_script_preference
+++ b/tests/028_boot_script_preference
@@ -31,13 +31,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/c/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/c/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/029_funny_named_boot_script
+++ b/tests/029_funny_named_boot_script
@@ -31,7 +31,6 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/myrelease/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/myrelease/releases/0.0.1.
@@ -39,6 +38,7 @@ erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
 erlinit: Found more than one boot file. Using a.boot.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/030_graceful_halt
+++ b/tests/030_graceful_halt
@@ -28,13 +28,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/031_graceful_reboot
+++ b/tests/031_graceful_reboot
@@ -28,13 +28,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/032_graceful_poweroff
+++ b/tests/032_graceful_poweroff
@@ -28,13 +28,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/033_ungraceful_halt
+++ b/tests/033_ungraceful_halt
@@ -28,13 +28,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/034_segfault
+++ b/tests/034_segfault
@@ -28,13 +28,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/035_working_directory
+++ b/tests/035_working_directory
@@ -30,13 +30,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/036_bad_working_directory
+++ b/tests/036_bad_working_directory
@@ -31,13 +31,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/037_graceful_timeout
+++ b/tests/037_graceful_timeout
@@ -30,13 +30,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/038_consolidated_protocols
+++ b/tests/038_consolidated_protocols
@@ -31,13 +31,13 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
 erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/039_multi_consolidated
+++ b/tests/039_multi_consolidated
@@ -34,7 +34,6 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: /srv/erlang/releases/start_erl.data not found.
 erlinit: Using release in /srv/erlang/releases/0.0.1.
@@ -42,6 +41,7 @@ erlinit: find_sys_config
 erlinit: find_vm_args
 erlinit: find_boot_path
 erlinit: More than one consolidated directory found. Using '/srv/erlang/lib/test-0.0.1/consolidated'
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/040_update_clock
+++ b/tests/040_update_clock
@@ -25,9 +25,9 @@ fixture: setsid()
 erlinit: checking that the clock is after the build timestamp
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/041_uniqueid_whitespace
+++ b/tests/041_uniqueid_whitespace
@@ -38,9 +38,9 @@ erlinit: set_ctty
 fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
-erlinit: find_erts_directory
 erlinit: find_release
 erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)

--- a/tests/042_multiple_erts_w_start_erl
+++ b/tests/042_multiple_erts_w_start_erl
@@ -1,34 +1,37 @@
 #!/bin/sh
 
 #
-# Test that calling out to a unique id generator does the right thing
+# Test that the start_erl.data file is read when picking a release to run.
 #
 
-cat >$CONFIG <<EOF
+cat >$CMDLINE_FILE <<EOF
 -v
-
-# Specify a hostname pattern that has a unique id part
---hostname-pattern nerves-%.4s
-
-# Call out to a dummy unique id generator
---uniqueid-exec "/usr/bin/make-unique-id"
 EOF
 
-cat >$WORK/usr/bin/make-unique-id <<EOF
-#!/bin/sh
+# Make a release
+RELEASE_PATH=$WORK/srv/erlang/releases/0.0.1
+mkdir -p $RELEASE_PATH
+touch $RELEASE_PATH/test.boot
+touch $RELEASE_PATH/sys.config
+touch $RELEASE_PATH/vm.args
 
-echo "0042"
+# Make a few ERTS directories
+mkdir -p $WORK/usr/lib/erlang/erts-6.1/bin
+mkdir -p $WORK/usr/lib/erlang/erts-7.0/bin
+mkdir -p $WORK/usr/lib/erlang/erts-8.3/bin
+ln -s $FAKE_ERLEXEC $WORK/usr/lib/erlang/erts-6.1/bin/erlexec
+ln -s $FAKE_ERLEXEC $WORK/usr/lib/erlang/erts-7.0/bin/erlexec
+ln -s $FAKE_ERLEXEC $WORK/usr/lib/erlang/erts-8.3/bin/erlexec
+
+# Create a start_erl.data that says which ERTS to use
+cat >$WORK/srv/erlang/releases/start_erl.data <<EOF
+8.3 0.0.1
 EOF
-chmod +x $WORK/usr/bin/make-unique-id
 
 cat >$EXPECTED <<EOF
-erlinit: cmdline argc=1, merged argc=6
+erlinit: cmdline argc=2, merged argc=2
 erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
-erlinit: merged argv[2]=--hostname-pattern
-erlinit: merged argv[3]=nerves-%.4s
-erlinit: merged argv[4]=--uniqueid-exec
-erlinit: merged argv[5]=/usr/bin/make-unique-id
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
@@ -39,7 +42,10 @@ fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
 erlinit: find_release
-erlinit: No release found in /srv/erlang.
+erlinit: Using release in /srv/erlang/releases/0.0.1.
+erlinit: find_sys_config
+erlinit: find_vm_args
+erlinit: find_boot_path
 erlinit: find_erts_directory
 erlinit: setup_environment
 erlinit: setup_networking
@@ -47,17 +53,21 @@ fixture: ioctl(SIOCGIFFLAGS)
 fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
-erlinit: system_cmd '/usr/bin/make-unique-id'
-erlinit: Hostname: nerves-0042
-fixture: sethostname("nerves-0042", 11)
+erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/root'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=vt100'
-erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
-erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'ROOTDIR=/srv/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-8.3/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-config'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/sys.config'
+erlinit: Arg: '-boot'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
+erlinit: Arg: '-args_file'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited


### PR DESCRIPTION
Rather than scanning for erts directories, try the one in start_erl.data
first. If it doesn't exist, emit a warning and scan for available erts
directories.

In production Nerves systems there really should only be one erts
directory. However, it is possible to have two in development and this
ensures that you get the right one. Getting a warning on the specified
one doesn't exist seems useful. One could argue that this is
a fatal error. Since it hasn't been a fatal error in the past and making
it a fatal error could brick some Nerves deployments that can't recover
from bad builds if Erlang code doesn't run, I'm leaving it as a warning
for now.