### PR TITLE
Change /dev/shm perms to 01777

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -81,8 +81,14 @@ void setup_pseudo_filesystems()
     OK_OR_WARN(mount("sysfs", "/sys", "sysfs", MS_NOEXEC | MS_NOSUID | MS_NODEV, NULL), "Cannot mount /sys");
 
     // /dev should be automatically created/mounted by Linux
+
+    // Create entries in /dev. Turn off the umask since we want the exact
+    // permissions that we're specifying.
+    mode_t old_umask = umask(0);
     OK_OR_WARN(mkdir("/dev/pts", 0755), "Cannot create /dev/pts");
-    OK_OR_WARN(mkdir("/dev/shm", 0755), "Cannot create /dev/shm");
+    OK_OR_WARN(mkdir("/dev/shm", 01777), "Cannot create /dev/shm");
+    umask(old_umask);
+
     OK_OR_WARN(mount("devpts", "/dev/pts", "devpts", MS_NOEXEC | MS_NOSUID, "gid=5,mode=620"), "Cannot mount /dev/pts");
 }
 

--- a/tests/001_cmdline_verbose
+++ b/tests/001_cmdline_verbose
@@ -15,7 +15,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/002_config_verbose
+++ b/tests/002_config_verbose
@@ -15,7 +15,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/003_run_release
+++ b/tests/003_run_release
@@ -21,7 +21,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/004_run_deep_release
+++ b/tests/004_run_deep_release
@@ -22,7 +22,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/005_run_strace
+++ b/tests/005_run_strace
@@ -27,7 +27,7 @@ erlinit: merged argv[3]=/usr/bin/strace -f
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/006_env
+++ b/tests/006_env
@@ -17,7 +17,7 @@ erlinit: merged argv[3]=LANG=en_US.UTF-8;LANGUAGE=en
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/007_multi_release_paths
+++ b/tests/007_multi_release_paths
@@ -23,7 +23,7 @@ erlinit: merged argv[3]=/mnt/anotherplace:/srv/erlang
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/008_cmdline_verbose2
+++ b/tests/008_cmdline_verbose2
@@ -15,7 +15,7 @@ erlinit: merged argv[1]=--verbose
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -18,7 +18,7 @@ erlinit: merged argv[3]=/dev/mmcblk0p3:/root:vfat::
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/010_uniqueid
+++ b/tests/010_uniqueid
@@ -32,7 +32,7 @@ erlinit: merged argv[5]=/usr/bin/make-unique-id
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/011_etc_hostname
+++ b/tests/011_etc_hostname
@@ -19,7 +19,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/012_bad_option
+++ b/tests/012_bad_option
@@ -17,7 +17,7 @@ erlinit: merged argv[2]=--unknown-option
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/013_bad_option2
+++ b/tests/013_bad_option2
@@ -17,7 +17,7 @@ erlinit: merged argv[2]=-Z
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/014_tty_warning
+++ b/tests/014_tty_warning
@@ -30,7 +30,7 @@ erlinit: merged argv[4]=--warn-unused-tty
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/015_multi_mount
+++ b/tests/015_multi_mount
@@ -20,7 +20,7 @@ erlinit: merged argv[5]=/dev/mmcblk0p4:/mnt:ext4::
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/016_erlexec_boot_arg
+++ b/tests/016_erlexec_boot_arg
@@ -17,7 +17,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/017_erlexec_boot_arg_file
+++ b/tests/017_erlexec_boot_arg_file
@@ -17,7 +17,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/018_run_on_exit
+++ b/tests/018_run_on_exit
@@ -30,7 +30,7 @@ erlinit: merged argv[3]=/usr/bin/onexit
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/019_uid_and_gid
+++ b/tests/019_uid_and_gid
@@ -20,7 +20,7 @@ erlinit: merged argv[5]=200
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/020_pre_run_exec
+++ b/tests/020_pre_run_exec
@@ -30,7 +30,7 @@ erlinit: merged argv[3]=/usr/bin/prerun
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/021_multi_boot_script
+++ b/tests/021_multi_boot_script
@@ -24,7 +24,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/022_pick_boot_script
+++ b/tests/022_pick_boot_script
@@ -28,7 +28,7 @@ erlinit: merged argv[3]=/srv/erlang/releases/0.0.1/c
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/023_pick_boot_script2
+++ b/tests/023_pick_boot_script2
@@ -28,7 +28,7 @@ erlinit: merged argv[3]=c
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/024_pick_missing_boot_script
+++ b/tests/024_pick_missing_boot_script
@@ -27,7 +27,7 @@ erlinit: merged argv[3]=missing_boot_script
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/025_start_erl_data
+++ b/tests/025_start_erl_data
@@ -33,7 +33,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/026_bad_start_erl_data
+++ b/tests/026_bad_start_erl_data
@@ -34,7 +34,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/027_bad_start_erl_data2
+++ b/tests/027_bad_start_erl_data2
@@ -34,7 +34,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/028_boot_script_preference
+++ b/tests/028_boot_script_preference
@@ -25,7 +25,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/029_funny_named_boot_script
+++ b/tests/029_funny_named_boot_script
@@ -25,7 +25,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/030_graceful_halt
+++ b/tests/030_graceful_halt
@@ -22,7 +22,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/031_graceful_reboot
+++ b/tests/031_graceful_reboot
@@ -22,7 +22,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/032_graceful_poweroff
+++ b/tests/032_graceful_poweroff
@@ -22,7 +22,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/033_ungraceful_halt
+++ b/tests/033_ungraceful_halt
@@ -22,7 +22,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/034_segfault
+++ b/tests/034_segfault
@@ -22,7 +22,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/035_working_directory
+++ b/tests/035_working_directory
@@ -24,7 +24,7 @@ erlinit: merged argv[3]=/tmp
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/036_bad_working_directory
+++ b/tests/036_bad_working_directory
@@ -25,7 +25,7 @@ erlinit: merged argv[3]=/doesntexist
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/037_graceful_timeout
+++ b/tests/037_graceful_timeout
@@ -24,7 +24,7 @@ erlinit: merged argv[3]=15000
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/038_consolidated_protocols
+++ b/tests/038_consolidated_protocols
@@ -25,7 +25,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/039_multi_consolidated
+++ b/tests/039_multi_consolidated
@@ -28,7 +28,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/040_update_clock
+++ b/tests/040_update_clock
@@ -18,7 +18,7 @@ erlinit: merged argv[2]=--update-clock
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/041_uniqueid_whitespace
+++ b/tests/041_uniqueid_whitespace
@@ -32,7 +32,7 @@ erlinit: merged argv[5]=/usr/bin/make-unique-id
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()

--- a/tests/042_multiple_erts_w_start_erl
+++ b/tests/042_multiple_erts_w_start_erl
@@ -35,7 +35,7 @@ erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mkdir("/dev/pts", 755)
-fixture: mkdir("/dev/shm", 755)
+fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
 erlinit: set_ctty
 fixture: setsid()


### PR DESCRIPTION
They were 0755. Other operating systems have them at 01777 so that
non-root applications can create shared memory. Chromium creates shared
memory blocks, so this is needed for it (unless you're running Chromium
as root).