### PR TITLE
Fix root disk detection for NVME disks

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -101,7 +101,7 @@ static dev_t root_disk_device()
     //       get its parent.
     struct stat rootdev;
     if (stat("/", &rootdev) >= 0) {
-        return (rootdev.st_dev & 0xfff0);
+        return (rootdev.st_dev & ~0xf);
     } else {
         warn("Could not determine root device: %s", strerror(errno));
         return 0;


### PR DESCRIPTION
NVME disks have a device type with a major number of 0x103. This was
being masked off causing the rootdisk symlinks to not be created.

Fixes #39.