### PR TITLE
Use a dummy id if the unique id program fails

### DIFF
--- a/src/hostname.c
+++ b/src/hostname.c
@@ -26,6 +26,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <ctype.h>
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -64,10 +65,16 @@ void configure_hostname()
 
     if (options.hostname_pattern) {
         // Set the hostname based on a pattern
-        char unique_id[64] = "xxxxxxxx";
+        const char *default_unique_id = "00000000";
+        const char *unique_id = default_unique_id;
+        char buffer[64];
         if (options.uniqueid_exec) {
-            system_cmd(options.uniqueid_exec, unique_id, sizeof(unique_id));
-            kill_whitespace(unique_id);
+            if (system_cmd(options.uniqueid_exec, buffer, sizeof(buffer)) == EXIT_SUCCESS) {
+                kill_whitespace(buffer);
+                unique_id = buffer;
+            } else {
+                warn("`%s` failed. Using default ID: '%s'", options.uniqueid_exec, unique_id);
+            }
         }
         sprintf(hostname, options.hostname_pattern, unique_id);
         kill_whitespace(hostname);

--- a/tests/043_bad_uniqueid
+++ b/tests/043_bad_uniqueid
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+#
+# Test that calling out to a unique id generator that fails still boots
+#
+
+cat >$CONFIG <<EOF
+-v
+
+# Specify a hostname pattern that has a unique id part
+--hostname-pattern nerves-%.4s
+
+# Call out to a dummy unique id generator that fails
+--uniqueid-exec "/usr/bin/make-unique-id"
+EOF
+
+cat >$WORK/usr/bin/make-unique-id <<EOF
+#!/bin/sh
+
+echo "ERROR ROAR bad bad"
+exit 1
+EOF
+chmod +x $WORK/usr/bin/make-unique-id
+
+cat >$EXPECTED <<EOF
+erlinit: cmdline argc=1, merged argc=6
+erlinit: merged argv[0]=/sbin/init
+erlinit: merged argv[1]=-v
+erlinit: merged argv[2]=--hostname-pattern
+erlinit: merged argv[3]=nerves-%.4s
+erlinit: merged argv[4]=--uniqueid-exec
+erlinit: merged argv[5]=/usr/bin/make-unique-id
+fixture: mount("proc", "/proc", "proc", 14, data)
+fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mkdir("/dev/pts", 755)
+fixture: mkdir("/dev/shm", 1777)
+fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
+erlinit: set_ctty
+fixture: setsid()
+fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
+fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
+erlinit: find_release
+erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
+erlinit: setup_environment
+erlinit: setup_networking
+fixture: ioctl(SIOCGIFFLAGS)
+fixture: ioctl(SIOCSIFFLAGS)
+fixture: ioctl(SIOCGIFINDEX)
+erlinit: configure_hostname
+erlinit: system_cmd '/usr/bin/make-unique-id'
+erlinit: '/usr/bin/make-unique-id' failed. Using default ID: '00000000'
+erlinit: Hostname: nerves-0000
+fixture: sethostname("nerves-0000", 11)
+erlinit: Env: 'HOME=/root'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erl'
+erlinit: Arg: 'erlexec'
+erlinit: Launching erl...
+Hello from erlexec
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: Sending SIGTERM to all processes
+fixture: kill(-1, 15)
+fixture: sleep(1)
+erlinit: Sending SIGKILL to all processes
+fixture: kill(-1, 9)
+erlinit: unmount_all
+erlinit: unmounting tmpfs at /sys/fs/cgroup...
+fixture: umount("/sys/fs/cgroup")
+erlinit: unmounting tmpfs at /dev/shm...
+fixture: umount("/dev/shm")
+erlinit: unmounting devpts at /dev/pts...
+fixture: umount("/dev/pts")
+erlinit: unmounting proc at /proc...
+fixture: umount("/proc")
+erlinit: unmounting sysfs at /sys...
+fixture: umount("/sys")
+EOF


### PR DESCRIPTION
This prevents error messages from being used as part of the hostname
(assuming that the unique ID program returns error).