### PR TITLE
Normalize hostnames and remove invalid characters

### DIFF
--- a/src/hostname.c
+++ b/src/hostname.c
@@ -58,6 +58,31 @@ static void kill_whitespace(char *s)
     }
 }
 
+static void make_rfc1123_compatible(char *s)
+{
+    // This function modifies the hostname to make sure that it's compatible
+    // with RFC 1123. I.e. a-z, 0-9, -, and '.'. Capitals are made lowercase
+    // for consistency with tools that automatically normalize capitalization.
+    // Invalid characters are removed.
+    char *d = s;
+    while (*s) {
+      char c = *s;
+      if ((c >= 'a' && c <= 'z') ||
+          (c >= '0' && c <= '9') ||
+          c == '-' || c == '.') {
+          // Good
+          *d = c;
+          d++;
+      } else if (c >= 'A' && c <= 'Z') {
+          // Make lowercase
+          *d = c - 'A' + 'a';
+          d++;
+      }
+      s++;
+    }
+    *d = '\0';
+}
+
 void configure_hostname()
 {
     debug("configure_hostname");
@@ -78,6 +103,7 @@ void configure_hostname()
         }
         sprintf(hostname, options.hostname_pattern, unique_id);
         kill_whitespace(hostname);
+        make_rfc1123_compatible(hostname);
     } else {
         // Set the hostname from /etc/hostname
         FILE *fp = fopen("/etc/hostname", "r");

--- a/tests/044_hostname_bad_chars
+++ b/tests/044_hostname_bad_chars
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+#
+# Test that specifying a hostname with bad characters gets fixed
+#
+
+cat >$CONFIG <<EOF
+-v
+
+--hostname-pattern NERVES
+EOF
+
+cat >$EXPECTED <<EOF
+erlinit: cmdline argc=1, merged argc=4
+erlinit: merged argv[0]=/sbin/init
+erlinit: merged argv[1]=-v
+erlinit: merged argv[2]=--hostname-pattern
+erlinit: merged argv[3]=NERVES
+fixture: mount("proc", "/proc", "proc", 14, data)
+fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mkdir("/dev/pts", 755)
+fixture: mkdir("/dev/shm", 1777)
+fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
+erlinit: set_ctty
+fixture: setsid()
+fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
+fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
+erlinit: find_release
+erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
+erlinit: setup_environment
+erlinit: setup_networking
+fixture: ioctl(SIOCGIFFLAGS)
+fixture: ioctl(SIOCSIFFLAGS)
+fixture: ioctl(SIOCGIFINDEX)
+erlinit: configure_hostname
+erlinit: Hostname: nerves
+fixture: sethostname("nerves", 6)
+erlinit: Env: 'HOME=/root'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erl'
+erlinit: Arg: 'erlexec'
+erlinit: Launching erl...
+Hello from erlexec
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: Sending SIGTERM to all processes
+fixture: kill(-1, 15)
+fixture: sleep(1)
+erlinit: Sending SIGKILL to all processes
+fixture: kill(-1, 9)
+erlinit: unmount_all
+erlinit: unmounting tmpfs at /sys/fs/cgroup...
+fixture: umount("/sys/fs/cgroup")
+erlinit: unmounting tmpfs at /dev/shm...
+fixture: umount("/dev/shm")
+erlinit: unmounting devpts at /dev/pts...
+fixture: umount("/dev/pts")
+erlinit: unmounting proc at /proc...
+fixture: umount("/proc")
+erlinit: unmounting sysfs at /sys...
+fixture: umount("/sys")
+EOF

--- a/tests/045_hostname_bad_chars2
+++ b/tests/045_hostname_bad_chars2
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+#
+# Test that specifying a hostname with bad characters gets fixed
+#
+
+cat >$CONFIG <<EOF
+-v
+
+--hostname-pattern N__ERVES
+EOF
+
+cat >$EXPECTED <<EOF
+erlinit: cmdline argc=1, merged argc=4
+erlinit: merged argv[0]=/sbin/init
+erlinit: merged argv[1]=-v
+erlinit: merged argv[2]=--hostname-pattern
+erlinit: merged argv[3]=N__ERVES
+fixture: mount("proc", "/proc", "proc", 14, data)
+fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mkdir("/dev/pts", 755)
+fixture: mkdir("/dev/shm", 1777)
+fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
+erlinit: set_ctty
+fixture: setsid()
+fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
+fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
+erlinit: find_release
+erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
+erlinit: setup_environment
+erlinit: setup_networking
+fixture: ioctl(SIOCGIFFLAGS)
+fixture: ioctl(SIOCSIFFLAGS)
+fixture: ioctl(SIOCGIFINDEX)
+erlinit: configure_hostname
+erlinit: Hostname: nerves
+fixture: sethostname("nerves", 6)
+erlinit: Env: 'HOME=/root'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erl'
+erlinit: Arg: 'erlexec'
+erlinit: Launching erl...
+Hello from erlexec
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: Sending SIGTERM to all processes
+fixture: kill(-1, 15)
+fixture: sleep(1)
+erlinit: Sending SIGKILL to all processes
+fixture: kill(-1, 9)
+erlinit: unmount_all
+erlinit: unmounting tmpfs at /sys/fs/cgroup...
+fixture: umount("/sys/fs/cgroup")
+erlinit: unmounting tmpfs at /dev/shm...
+fixture: umount("/dev/shm")
+erlinit: unmounting devpts at /dev/pts...
+fixture: umount("/dev/pts")
+erlinit: unmounting proc at /proc...
+fixture: umount("/proc")
+erlinit: unmounting sysfs at /sys...
+fixture: umount("/sys")
+EOF

--- a/tests/046_hostname_bad_chars3
+++ b/tests/046_hostname_bad_chars3
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+#
+# Test that specifying a hostname with bad characters gets fixed
+#
+
+cat >$CONFIG <<EOF
+-v
+
+--hostname-pattern A-bc-de._g
+EOF
+
+cat >$EXPECTED <<EOF
+erlinit: cmdline argc=1, merged argc=4
+erlinit: merged argv[0]=/sbin/init
+erlinit: merged argv[1]=-v
+erlinit: merged argv[2]=--hostname-pattern
+erlinit: merged argv[3]=A-bc-de._g
+fixture: mount("proc", "/proc", "proc", 14, data)
+fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mkdir("/dev/pts", 755)
+fixture: mkdir("/dev/shm", 1777)
+fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
+erlinit: set_ctty
+fixture: setsid()
+fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
+fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
+erlinit: find_release
+erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
+erlinit: setup_environment
+erlinit: setup_networking
+fixture: ioctl(SIOCGIFFLAGS)
+fixture: ioctl(SIOCSIFFLAGS)
+fixture: ioctl(SIOCGIFINDEX)
+erlinit: configure_hostname
+erlinit: Hostname: a-bc-de.g
+fixture: sethostname("a-bc-de.g", 9)
+erlinit: Env: 'HOME=/root'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erl'
+erlinit: Arg: 'erlexec'
+erlinit: Launching erl...
+Hello from erlexec
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: Sending SIGTERM to all processes
+fixture: kill(-1, 15)
+fixture: sleep(1)
+erlinit: Sending SIGKILL to all processes
+fixture: kill(-1, 9)
+erlinit: unmount_all
+erlinit: unmounting tmpfs at /sys/fs/cgroup...
+fixture: umount("/sys/fs/cgroup")
+erlinit: unmounting tmpfs at /dev/shm...
+fixture: umount("/dev/shm")
+erlinit: unmounting devpts at /dev/pts...
+fixture: umount("/dev/pts")
+erlinit: unmounting proc at /proc...
+fixture: umount("/proc")
+erlinit: unmounting sysfs at /sys...
+fixture: umount("/sys")
+EOF


### PR DESCRIPTION
This prevents some weirdness when auto-generated hostnames violate
RFC 1123 or have mixed case.