### PR TITLE
Open/close /dev/kmsg on each log attempt

### DIFF
--- a/src/erlinit.c
+++ b/src/erlinit.c
@@ -851,8 +851,6 @@ static void fork_and_wait(int *is_intentional_exit, int *desired_reboot_cmd)
 
 int main(int argc, char *argv[])
 {
-    log_init();
-
     if (getpid() != 1)
         fatal("Refusing to run since not pid 1");
 

--- a/src/erlinit.h
+++ b/src/erlinit.h
@@ -81,7 +81,6 @@ struct erlinit_options {
 extern struct erlinit_options options;
 
 // Logging functions
-void log_init(void);
 void debug(const char *fmt, ...);
 void warn(const char *fmt, ...);
 void fatal(const char *fmt, ...);

--- a/tests/fixture/erlinit_fixture.c
+++ b/tests/fixture/erlinit_fixture.c
@@ -182,7 +182,7 @@ OVERRIDE(int, open, (const char *pathname, int flags, ...))
 
     // Log to stderr
     if (strcmp(pathname, "/dev/kmsg") == 0)
-        return STDERR_FILENO;
+        return dup(STDERR_FILENO);
 
     char new_path[PATH_MAX];
     if (fixup_path(pathname, new_path) < 0)


### PR DESCRIPTION
Previously `/dev/kmsg` was opened at launch and then written to when
needed. There's a rate limit in the kernel of 10 kernel messages per
5 seconds -> see kernel/printk/printk.c. This affects verbose logging
from erlinit since dumping the commandline parameters is > 10 log
messages. Rather than modifying kernel's rate limit settings, this
change opens the log on demand. It avoids the rate limit in the
verbose case and feels better for normal case since there's one less
file handle that's open.