### PR TITLE
Add support for Elixir 1.9 generated boot scripts

### DIFF
--- a/src/erlinit.c
+++ b/src/erlinit.c
@@ -696,6 +696,11 @@ static void child()
         argv = concat_options(argv, ERLANG_ERTS_LIB_DIR, append);
     }
 
+    // Set the RELEASE_LIB boot_var for Elixir 1.9+ releases
+    argv = concat_options(argv, "-boot_var", append);
+    argv = concat_options(argv, "RELEASE_LIB", append);
+    argv = concat_options(argv, RELEASE_ROOT_LIB, append);
+
     if (options.verbose) {
         // Dump the environment and commandline
         extern char **environ;

--- a/src/erlinit.h
+++ b/src/erlinit.h
@@ -41,6 +41,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define ERLANG_ERTS_LIB_DIR ERLANG_ROOT_DIR "/lib"
 
 #define DEFAULT_RELEASE_ROOT_DIR "/srv/erlang"
+#define RELEASE_ROOT_LIB DEFAULT_RELEASE_ROOT_DIR "/lib"
 
 // This is the maximum number of mounted filesystems that
 // is expected in a running system. It is used on shutdown

--- a/tests/001_cmdline_verbose
+++ b/tests/001_cmdline_verbose
@@ -39,6 +39,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/002_config_verbose
+++ b/tests/002_config_verbose
@@ -39,6 +39,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/003_run_release
+++ b/tests/003_run_release
@@ -55,6 +55,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/004_run_deep_release
+++ b/tests/004_run_deep_release
@@ -56,6 +56,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/myrelease/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/myrelease/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/005_run_strace
+++ b/tests/005_run_strace
@@ -53,6 +53,9 @@ erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: '/usr/bin/strace'
 erlinit: Arg: '-f'
 erlinit: Arg: '/usr/lib/erlang/erts-6.0/bin/erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from strace
 erlinit: Erlang VM exited

--- a/tests/006_env
+++ b/tests/006_env
@@ -43,6 +43,9 @@ erlinit: Env: 'PROGNAME=erl'
 erlinit: Env: 'LANG=en_US.UTF-8'
 erlinit: Env: 'LANGUAGE=en'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/007_multi_release_paths
+++ b/tests/007_multi_release_paths
@@ -58,6 +58,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/008_cmdline_verbose2
+++ b/tests/008_cmdline_verbose2
@@ -39,6 +39,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -44,6 +44,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/010_uniqueid
+++ b/tests/010_uniqueid
@@ -58,6 +58,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/011_etc_hostname
+++ b/tests/011_etc_hostname
@@ -44,6 +44,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/012_bad_option
+++ b/tests/012_bad_option
@@ -41,6 +41,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/013_bad_option2
+++ b/tests/013_bad_option2
@@ -41,6 +41,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/014_tty_warning
+++ b/tests/014_tty_warning
@@ -55,6 +55,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/015_multi_mount
+++ b/tests/015_multi_mount
@@ -48,6 +48,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/016_erlexec_boot_arg
+++ b/tests/016_erlexec_boot_arg
@@ -44,6 +44,9 @@ erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'ERTS_LIB_DIR'
 erlinit: Arg: '/usr/lib/erlang/lib'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/017_erlexec_boot_arg_file
+++ b/tests/017_erlexec_boot_arg_file
@@ -41,6 +41,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/018_run_on_exit
+++ b/tests/018_run_on_exit
@@ -64,6 +64,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/019_uid_and_gid
+++ b/tests/019_uid_and_gid
@@ -48,6 +48,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/020_pre_run_exec
+++ b/tests/020_pre_run_exec
@@ -66,6 +66,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/021_multi_boot_script
+++ b/tests/021_multi_boot_script
@@ -59,6 +59,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/a'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/022_pick_boot_script
+++ b/tests/022_pick_boot_script
@@ -62,6 +62,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/c'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/023_pick_boot_script2
+++ b/tests/023_pick_boot_script2
@@ -62,6 +62,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/c'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/024_pick_missing_boot_script
+++ b/tests/024_pick_missing_boot_script
@@ -63,6 +63,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/a'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/025_start_erl_data
+++ b/tests/025_start_erl_data
@@ -67,6 +67,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.2/a'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.2/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/026_bad_start_erl_data
+++ b/tests/026_bad_start_erl_data
@@ -70,6 +70,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.3/a'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.3/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/027_bad_start_erl_data2
+++ b/tests/027_bad_start_erl_data2
@@ -69,6 +69,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.3/a'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.3/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/028_boot_script_preference
+++ b/tests/028_boot_script_preference
@@ -59,6 +59,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/c/releases/0.0.1/c'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/c/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/029_funny_named_boot_script
+++ b/tests/029_funny_named_boot_script
@@ -60,6 +60,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/myrelease/releases/0.0.1/a'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/myrelease/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/030_graceful_halt
+++ b/tests/030_graceful_halt
@@ -56,6 +56,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 erlexec is sending signal to halt
 erlinit: sigpwr|sigusr1 -> halt

--- a/tests/031_graceful_reboot
+++ b/tests/031_graceful_reboot
@@ -56,6 +56,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 erlexec is sending signal to reboot
 erlinit: sigterm -> reboot

--- a/tests/032_graceful_poweroff
+++ b/tests/032_graceful_poweroff
@@ -56,6 +56,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 erlexec is sending signal to poweroff
 erlinit: sigusr2 -> poweroff

--- a/tests/033_ungraceful_halt
+++ b/tests/033_ungraceful_halt
@@ -56,6 +56,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 erlexec is sending signal to halt
 erlinit: sigpwr|sigusr1 -> halt

--- a/tests/034_segfault
+++ b/tests/034_segfault
@@ -56,6 +56,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 erlexec is going to crash
 erlinit: Erlang terminated due to signal 11

--- a/tests/035_working_directory
+++ b/tests/035_working_directory
@@ -58,6 +58,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec in $WORK/tmp
 erlinit: Erlang VM exited

--- a/tests/036_bad_working_directory
+++ b/tests/036_bad_working_directory
@@ -59,6 +59,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec in $WORK/srv/erlang
 erlinit: Erlang VM exited

--- a/tests/037_graceful_timeout
+++ b/tests/037_graceful_timeout
@@ -58,6 +58,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 erlexec is sending signal to halt
 erlinit: sigpwr|sigusr1 -> halt

--- a/tests/038_consolidated_protocols
+++ b/tests/038_consolidated_protocols
@@ -61,6 +61,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/039_multi_consolidated
+++ b/tests/039_multi_consolidated
@@ -65,6 +65,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/040_update_clock
+++ b/tests/040_update_clock
@@ -43,6 +43,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/041_uniqueid_whitespace
+++ b/tests/041_uniqueid_whitespace
@@ -58,6 +58,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/042_multiple_erts_w_start_erl
+++ b/tests/042_multiple_erts_w_start_erl
@@ -68,6 +68,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/043_bad_uniqueid
+++ b/tests/043_bad_uniqueid
@@ -60,6 +60,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/044_hostname_bad_chars
+++ b/tests/044_hostname_bad_chars
@@ -44,6 +44,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/045_hostname_bad_chars2
+++ b/tests/045_hostname_bad_chars2
@@ -44,6 +44,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/046_hostname_bad_chars3
+++ b/tests/046_hostname_bad_chars3
@@ -44,6 +44,9 @@ erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/047_alternate_exec
+++ b/tests/047_alternate_exec
@@ -69,6 +69,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from altexec
 Args:
@@ -79,6 +82,9 @@ Args:
   /srv/erlang/releases/0.0.1/test
   -args_file
   /srv/erlang/releases/0.0.1/vm.args
+  -boot_var
+  RELEASE_LIB
+  /srv/erlang/lib
 erlinit: Erlang VM exited
 erlinit: kill_all
 erlinit: Sending SIGTERM to all processes

--- a/tests/048_alternate_exec_multiargs
+++ b/tests/048_alternate_exec_multiargs
@@ -72,6 +72,9 @@ erlinit: Arg: '-boot'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
 erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
 erlinit: Launching erl...
 Hello from altexec
 Args:
@@ -85,6 +88,9 @@ Args:
   /srv/erlang/releases/0.0.1/test
   -args_file
   /srv/erlang/releases/0.0.1/vm.args
+  -boot_var
+  RELEASE_LIB
+  /srv/erlang/lib
 erlinit: Erlang VM exited
 erlinit: kill_all
 erlinit: Sending SIGTERM to all processes

--- a/tests/049_alternate_exec_exec
+++ b/tests/049_alternate_exec_exec
@@ -68,13 +68,13 @@ erlinit: Env: 'PROGNAME=erl'
 erlinit: Arg: '/usr/bin/altexec'
 erlinit: Arg: '1'
 erlinit: Arg: '2'
-erlinit: Arg: 'exec 3 /usr/lib/erlang/erts-6.0/bin/erlexec -config /srv/erlang/releases/0.0.1/sys.config -boot /srv/erlang/releases/0.0.1/test -args_file /srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: 'exec 3 /usr/lib/erlang/erts-6.0/bin/erlexec -config /srv/erlang/releases/0.0.1/sys.config -boot /srv/erlang/releases/0.0.1/test -args_file /srv/erlang/releases/0.0.1/vm.args -boot_var RELEASE_LIB /srv/erlang/lib'
 erlinit: Launching erl...
 Hello from altexec
 Args:
   1
   2
-  exec 3 /usr/lib/erlang/erts-6.0/bin/erlexec -config /srv/erlang/releases/0.0.1/sys.config -boot /srv/erlang/releases/0.0.1/test -args_file /srv/erlang/releases/0.0.1/vm.args
+  exec 3 /usr/lib/erlang/erts-6.0/bin/erlexec -config /srv/erlang/releases/0.0.1/sys.config -boot /srv/erlang/releases/0.0.1/test -args_file /srv/erlang/releases/0.0.1/vm.args -boot_var RELEASE_LIB /srv/erlang/lib
 erlinit: Erlang VM exited
 erlinit: kill_all
 erlinit: Sending SIGTERM to all processes


### PR DESCRIPTION
This PR adds the `-boot_var` `RELEASE_LIB` which adds support for the boot scripts that Elixir 1.9 generates.