### PR TITLE
Add --tty-options parameter for initializing tty

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,11 @@ The following lists the options:
     Print out when erlinit starts and when it launches Erlang (for
     benchmarking)
 
+--tty-options <baud>[<parity><bits>]
+    Initialize the tty to the specified baud rate, parity and bits. This
+    option follows the [Linux kernel format](https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html),
+    but currently only 9600-115200 baud rates are supported.
+
 --uid <id>
     Run the Erlang VM under the specified user ID
 

--- a/src/erlinit.h
+++ b/src/erlinit.h
@@ -78,6 +78,7 @@ struct erlinit_options {
     int gid;
     int graceful_shutdown_timeout_ms;
     int update_clock;
+    char *tty_options;
 };
 
 extern struct erlinit_options options;

--- a/src/options.c
+++ b/src/options.c
@@ -1,7 +1,7 @@
 /*
 The MIT License (MIT)
 
-Copyright (c) 2013-16 Frank Hunleth
+Copyright (c) 2013-20 Frank Hunleth
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -85,7 +85,8 @@ enum erlinit_option_value {
     OPT_PRE_RUN_EXEC,
     OPT_GRACEFUL_SHUTDOWN_TIMEOUT,
     OPT_UPDATE_CLOCK,
-    OPT_RELEASE_INCLUDE_ERTS
+    OPT_RELEASE_INCLUDE_ERTS,
+    OPT_TTY_OPTIONS
 };
 
 static struct option long_options[] = {
@@ -114,6 +115,7 @@ static struct option long_options[] = {
     {"pre-run-exec", required_argument, 0, OPT_PRE_RUN_EXEC },
     {"graceful-shutdown-timeout", required_argument, 0, OPT_GRACEFUL_SHUTDOWN_TIMEOUT },
     {"update-clock", no_argument, 0, OPT_UPDATE_CLOCK },
+    {"tty-options", required_argument, 0, OPT_TTY_OPTIONS},
     {0,     0,      0, 0 }
 };
 
@@ -216,6 +218,9 @@ void parse_args(int argc, char *argv[])
             break;
         case OPT_UPDATE_CLOCK: // --update-clock
             options.update_clock = 1;
+            break;
+        case OPT_TTY_OPTIONS: // --tty-options 115200n8
+            SET_STRING_OPTION(options.tty_options);
             break;
         default:
             // getopt prints a warning, so we don't have to

--- a/tests/052_configure_tty
+++ b/tests/052_configure_tty
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+#
+# Test the --tty-option can set 115200n8
+#
+
+cat >$CONFIG <<EOF
+-v
+--tty-options 115200n8
+EOF
+
+cat >$EXPECTED <<EOF
+erlinit: cmdline argc=1, merged argc=4
+erlinit: merged argv[0]=/sbin/init
+erlinit: merged argv[1]=-v
+erlinit: merged argv[2]=--tty-options
+erlinit: merged argv[3]=115200n8
+fixture: mount("proc", "/proc", "proc", 14, data)
+fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mkdir("/dev/pts", 755)
+fixture: mkdir("/dev/shm", 1777)
+fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
+fixture: symlink("/dev/mmcblk0","/dev/rootdisk0")
+fixture: symlink("/dev/mmcblk0p4","/dev/rootdisk0p4")
+fixture: symlink("/dev/mmcblk0p3","/dev/rootdisk0p3")
+fixture: symlink("/dev/mmcblk0p2","/dev/rootdisk0p2")
+fixture: symlink("/dev/mmcblk0p1","/dev/rootdisk0p1")
+erlinit: set_ctty
+fixture: setsid()
+fixture: tcgetattr
+fixture: tcsetattr(0, iflag=0, oflag=0, cflag=18b2, lflag=0
+fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
+fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
+erlinit: find_release
+erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
+erlinit: setup_environment
+erlinit: setup_networking
+fixture: ioctl(SIOCGIFFLAGS)
+fixture: ioctl(SIOCSIFFLAGS)
+fixture: ioctl(SIOCGIFINDEX)
+erlinit: configure_hostname
+erlinit: /etc/hostname not found
+erlinit: Env: 'HOME=/root'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erlexec'
+erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
+erlinit: Launching erl...
+Hello from erlexec
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: Sending SIGTERM to all processes
+fixture: kill(-1, 15)
+fixture: sleep(1)
+erlinit: Sending SIGKILL to all processes
+fixture: kill(-1, 9)
+erlinit: unmount_all
+erlinit: unmounting tmpfs at /sys/fs/cgroup...
+fixture: umount("/sys/fs/cgroup")
+erlinit: unmounting tmpfs at /dev/shm...
+fixture: umount("/dev/shm")
+erlinit: unmounting devpts at /dev/pts...
+fixture: umount("/dev/pts")
+erlinit: unmounting proc at /proc...
+fixture: umount("/proc")
+erlinit: unmounting sysfs at /sys...
+fixture: umount("/sys")
+EOF

--- a/tests/fixture/erlinit_fixture.c
+++ b/tests/fixture/erlinit_fixture.c
@@ -17,6 +17,7 @@
 #include <sys/ioctl.h>
 #include <net/if.h>
 #include <glob.h>
+#include <termios.h>
 
 #define log(MSG, ...) do { fprintf(stderr, "fixture: " MSG "\n", ## __VA_ARGS__); } while (0)
 
@@ -165,6 +166,27 @@ REPLACE(int, setgid, (gid_t gid))
 REPLACE(int, kill, (pid_t pid, int sig))
 {
     log("kill(%d, %d)", pid, sig);
+    return 0;
+}
+
+REPLACE(int, tcgetattr, (int fd, struct termios *termios_p))
+{
+    log("tcgetattr");
+
+    memset(termios_p, 0, sizeof(struct termios));
+
+    return 0;
+}
+
+REPLACE(int, tcsetattr, (int fd, int optional_actions, const struct termios *termios_p))
+{
+    log("tcsetattr(%d, iflag=%x, oflag=%x, cflag=%x, lflag=%x",
+        optional_actions,
+        termios_p->c_iflag,
+        termios_p->c_oflag,
+        termios_p->c_cflag,
+        termios_p->c_lflag);
+
     return 0;
 }
 


### PR DESCRIPTION
This makes it possible to initialize a tty via erlinit. Previously
erlinit relied on the Linux kernel to initialize the tty, but it would
only do this if specified via commandline paramters (e.g.,
console=ttyS0,115200n8). If the kernel didn't have this option set, it
can be inconvenient to enable and possibly confusing when no prints
come out.