### PR TITLE
Add support for creating a shutdown report on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ The following lists the options:
 -s, --alternate-exec <program and arguments>
     Run another program that starts Erlang up. The arguments to `erlexec` are passed afterwards.
 
+--shutdown-report <path>
+    Before shutting down or rebooting, save a report to the specified path.
+
 -t, --print-timing
     Print out when erlinit starts and when it launches Erlang (for
     benchmarking)
@@ -228,6 +231,12 @@ For debug purposes and if `/dev/kmsg` cannot be opened, logging goes to
 `stderr` can block. In some scenarios, it can block indefinitely (e.g., logging
 to a gadget serial device).
 
+## Shutdown reports
+
+`erlinit` can help debug unexpected reboots and poweroffs. If you specify a path
+to `--shutdown-report`, `erlinit` will save what it knows about why and when
+Erlang exited.
+
 ## Debugging erlinit
 
 Since `erlinit` is the first user process run, it can be a little tricky to
@@ -266,12 +275,12 @@ for options.
 ## Hostnames
 
 `erlinit` can set the hostname of the system so that it is available when Erlang
-starts up. Do this by passing the hostname as the `-n` argument to `erlinit`, or 
+starts up. Do this by passing the hostname as the `-n` argument to `erlinit`, or
 hardcoding it in `/etc/hostname`.
 
 The `-n` argument takes a
 printf(3) formatted string that is passed a string argument, which
-is found by running the command specified by `-d`. This makes it possible to 
+is found by running the command specified by `-d`. This makes it possible to
 specify a unique ID, or some other information present on the file
 system. For example, if a _getmyid_ command is
 available that prints a unique identifier to stdout, it can be used to define the

--- a/src/erlinit.h
+++ b/src/erlinit.h
@@ -24,6 +24,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef ERLINIT_H
 #define ERLINIT_H
 
+#include <time.h>
+
 #define PROGRAM_NAME "erlinit"
 #ifndef PROGRAM_VERSION
 #error PROGRAM_VERSION is undefined
@@ -79,9 +81,19 @@ struct erlinit_options {
     int graceful_shutdown_timeout_ms;
     int update_clock;
     char *tty_options;
+    char *shutdown_report;
 };
 
 extern struct erlinit_options options;
+
+struct erlinit_exit_info {
+    int is_intentional_exit;
+    int desired_reboot_cmd;
+    int wait_status;
+    struct timespec shutdown_start;
+    struct timespec shutdown_complete;
+    int graceful_shutdown_ok;
+};
 
 // Logging functions
 void debug(const char *fmt, ...);
@@ -113,6 +125,9 @@ void warn_unused_tty(void);
 
 // External commands
 int system_cmd(const char *cmd, char *output_buffer, int length);
+
+// Shutdown report
+void shutdown_report_create(const char *path, const struct erlinit_exit_info *info);
 
 #ifdef __APPLE__
 #include "compat.h"

--- a/src/options.c
+++ b/src/options.c
@@ -52,7 +52,8 @@ struct erlinit_options options = {
     .gid = 0,
     .uid = 0,
     .graceful_shutdown_timeout_ms = 10000,
-    .update_clock = 0
+    .update_clock = 0,
+    .shutdown_report = NULL
 };
 
 enum erlinit_option_value {
@@ -86,7 +87,8 @@ enum erlinit_option_value {
     OPT_GRACEFUL_SHUTDOWN_TIMEOUT,
     OPT_UPDATE_CLOCK,
     OPT_RELEASE_INCLUDE_ERTS,
-    OPT_TTY_OPTIONS
+    OPT_TTY_OPTIONS,
+    OPT_SHUTDOWN_REPORT
 };
 
 static struct option long_options[] = {
@@ -116,6 +118,7 @@ static struct option long_options[] = {
     {"graceful-shutdown-timeout", required_argument, 0, OPT_GRACEFUL_SHUTDOWN_TIMEOUT },
     {"update-clock", no_argument, 0, OPT_UPDATE_CLOCK },
     {"tty-options", required_argument, 0, OPT_TTY_OPTIONS},
+    {"shutdown-report", required_argument, 0, OPT_SHUTDOWN_REPORT},
     {0,     0,      0, 0 }
 };
 
@@ -221,6 +224,9 @@ void parse_args(int argc, char *argv[])
             break;
         case OPT_TTY_OPTIONS: // --tty-options 115200n8
             SET_STRING_OPTION(options.tty_options);
+            break;
+        case OPT_SHUTDOWN_REPORT: // --shutdown-report /root/shutdown.txt
+            SET_STRING_OPTION(options.shutdown_report);
             break;
         default:
             // getopt prints a warning, so we don't have to

--- a/src/shutdown_report.c
+++ b/src/shutdown_report.c
@@ -1,0 +1,161 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2020 Frank Hunleth
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "erlinit.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <linux/reboot.h>
+#include <time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char *reboot_cmd(int cmd)
+{
+    switch (cmd) {
+    case LINUX_REBOOT_CMD_RESTART: return "restart";
+    case LINUX_REBOOT_CMD_HALT: return "halt";
+    case LINUX_REBOOT_CMD_POWER_OFF: return "power off";
+    default: return "unknown";
+    }
+}
+
+static const char *yes_or_no(int value)
+{
+    return value ? "yes" : "no";
+}
+
+static double delta_seconds(const struct timespec *ts1, const struct timespec *ts2)
+{
+    double first = ts1->tv_sec + ts1->tv_nsec * 0.0000000001;
+    double second = ts2->tv_sec + ts2->tv_nsec * 0.0000000001;
+    return second - first;
+}
+
+static void report_uptime(FILE *fp)
+{
+    struct timespec tp;
+    clock_gettime(CLOCK_MONOTONIC, &tp);
+    div_t q;
+    q = div(tp.tv_sec, 60);
+    int seconds = q.rem;
+    q = div(q.quot, 60);
+    int minutes = q.rem;
+    q = div(q.quot, 24);
+    int hours = q.rem;
+    int days = q.quot;
+
+    fprintf(fp, "Uptime: %d days, %d:%02d:%02d\n", days, hours, minutes, seconds);
+}
+
+static void report_current_time(FILE *fp)
+{
+    char buffer[64];
+
+    struct timespec tp;
+    clock_gettime(CLOCK_REALTIME, &tp);
+    time_t now;
+    now = tp.tv_sec;
+    struct tm result;
+    fprintf(fp, "Current time: %s", asctime_r(gmtime_r(&now, &result), buffer));
+}
+
+static void report_exit_info(FILE *fp, const struct erlinit_exit_info *exit_info)
+{
+    fprintf(fp, "Intention exit: %s\n", yes_or_no(exit_info->is_intentional_exit));
+    fprintf(fp, "Graceful shutdown succeeded: %s\n", yes_or_no(exit_info->graceful_shutdown_ok));
+    fprintf(fp, "Graceful shutdown time: ");
+    double shutdown_seconds = delta_seconds(&exit_info->shutdown_start, &exit_info->shutdown_complete);
+    if (shutdown_seconds > 0)
+        fprintf(fp, "%.3f seconds\n", shutdown_seconds);
+    else
+        fprintf(fp, "N/A\n");
+
+    if (WIFEXITED(exit_info->wait_status))
+       fprintf(fp, "Erlang exit status: %d\n", WEXITSTATUS(exit_info->wait_status));
+    if (WIFSIGNALED(exit_info->wait_status))
+       fprintf(fp, "Erlang exited due to signal: %d\n", WTERMSIG(exit_info->wait_status));
+    fprintf(fp, "Shutdown action: %s\n", reboot_cmd(exit_info->desired_reboot_cmd));
+}
+
+static void report_dmesg(FILE *fp)
+{
+    fprintf(fp, "\n## dmesg\n\n");
+
+    int fd = open("/dev/kmsg", O_RDONLY|O_NONBLOCK);
+    if (fd < 0) {
+        fprintf(fp, "Error opening /dev/kmsg: %s\n", strerror(errno));
+        return;
+    }
+
+    fprintf(fp, "```\n");
+    int in_message = 0;
+    for (;;) {
+        char buffer[4096];
+        ssize_t num_read = read(fd, buffer, sizeof(buffer));
+        if (num_read <= 0)
+            break;
+
+        // Trivial log parser that prints the messages
+        int start_ix = 0;
+        for (int i = 0; i < num_read; i++) {
+            if (in_message && buffer[i] == '\n') {
+                fwrite(&buffer[start_ix], 1, i + 1 - start_ix, fp);
+                start_ix = i + 1;
+                in_message = 0;
+            } else if (!in_message && buffer[i] == ';') {
+                start_ix = i + 1;
+                in_message = 1;
+            }
+        }
+        if (in_message)
+            fwrite(&buffer[start_ix], 1, num_read - start_ix, fp);
+    }
+    close(fd);
+    fprintf(fp, "```\n");
+}
+
+void shutdown_report_create(const char *path, const struct erlinit_exit_info *exit_info)
+{
+    debug("Writing shutdown report to '%s'", path);
+
+    FILE *fp = fopen(path, "w");
+    if (fp == NULL) {
+        warn("Failed to write shutdown dump to '%s'", path);
+        return;
+    }
+    fprintf(fp, "# Erlinit shutdown report\n\n");
+
+    report_uptime(fp);
+
+    report_current_time(fp);
+
+    report_exit_info(fp, exit_info);
+
+    report_dmesg(fp);
+
+    fclose(fp);
+}

--- a/tests/054_shutdown_report
+++ b/tests/054_shutdown_report
@@ -1,0 +1,120 @@
+#!/bin/sh
+
+#
+# Test that saving a shutdown report works.
+#
+# Note: This only tests that the code runs and not that the report looks ok.
+#
+
+cat >$CMDLINE_FILE <<EOF
+-v --shutdown-report /shutdown.txt
+EOF
+
+cat >$WORK/dev/kmsg <<EOF
+5,0,0,-;Linux version 5.4.0-48-generic (buildd@lcy01-amd64-010) (gcc version 9.3.0 (Ubuntu 9.3.0-10ubuntu2)) #52-Ubuntu SMP Thu Sep 10 10:58:49 UTC 2020 (Ubuntu 5.4.0-48.52-generic 5.4.60)
+6,1,0,-;Command line: BOOT_IMAGE=/boot/vmlinuz-5.4.0-48-generic root=UUID=a4c0bdf3-a932-4867-bc25-b20b6f17a209 ro quiet splash vt.handoff=7
+6,2,0,-;KERNEL supported cpus:
+6,3,0,-;  Intel GenuineIntel
+6,4,0,-;  AMD AuthenticAMD
+6,5,0,-;  Hygon HygonGenuine
+6,6,0,-;  Centaur CentaurHauls
+6,7,0,-;  zhaoxin   Shanghai
+6,8,0,-;x86/fpu: Supporting XSAVE feature 0x001: 'x87 floating point registers'
+6,9,0,-;x86/fpu: Supporting XSAVE feature 0x002: 'SSE registers'
+3,1606,879450394488,-;igb 0000:06:00.0 enp6s0: Reset adapter
+ SUBSYSTEM=pci
+ DEVICE=+pci:0000:06:00.0
+6,1607,879454003020,-;igb 0000:06:00.0 enp6s0: igb: enp6s0 NIC Link is Up 1000 Mbps Full Duplex, Flow Control: RX/TX
+ SUBSYSTEM=pci
+ DEVICE=+pci:0000:06:00.0
+3,1608,879474458726,-;igb 0000:06:00.0 enp6s0: Reset adapter
+ SUBSYSTEM=pci
+ DEVICE=+pci:0000:06:00.0
+6,1609,879478078990,-;igb 0000:06:00.0 enp6s0: igb: enp6s0 NIC Link is Up 1000 Mbps Full Duplex, Flow Control: RX/TX
+ SUBSYSTEM=pci
+ DEVICE=+pci:0000:06:00.0
+5,1610,912127562742,-;audit: type=1400 audit(1601784002.044:53): apparmor="DENIED" operation="capable" profile="/usr/sbin/cups-browsed" pid=3673509 comm="cups-browsed" capability=23  capname="sys_nice"
+EOF
+
+RELEASE_PATH=$WORK/srv/erlang/releases/0.0.1
+mkdir -p $RELEASE_PATH
+touch $RELEASE_PATH/test.boot
+touch $RELEASE_PATH/sys.config
+touch $RELEASE_PATH/vm.args
+ln -sf $FAKE_ERLEXEC.reboot $FAKE_ERTS_DIR/bin/erlexec
+
+cat >$EXPECTED <<EOF
+erlinit: cmdline argc=4, merged argc=4
+erlinit: merged argv[0]=/sbin/init
+erlinit: merged argv[1]=-v
+erlinit: merged argv[2]=--shutdown-report
+erlinit: merged argv[3]=/shutdown.txt
+fixture: mount("proc", "/proc", "proc", 14, data)
+fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mkdir("/dev/pts", 755)
+fixture: mkdir("/dev/shm", 1777)
+fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
+fixture: symlink("/dev/mmcblk0","/dev/rootdisk0")
+fixture: symlink("/dev/mmcblk0p4","/dev/rootdisk0p4")
+fixture: symlink("/dev/mmcblk0p3","/dev/rootdisk0p3")
+fixture: symlink("/dev/mmcblk0p2","/dev/rootdisk0p2")
+fixture: symlink("/dev/mmcblk0p1","/dev/rootdisk0p1")
+erlinit: set_ctty
+fixture: setsid()
+fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
+fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
+erlinit: find_release
+erlinit: /srv/erlang/releases/start_erl.data not found.
+erlinit: Using release in /srv/erlang/releases/0.0.1.
+erlinit: find_sys_config
+erlinit: find_vm_args
+erlinit: find_boot_path
+erlinit: find_erts_directory
+erlinit: setup_environment
+erlinit: setup_networking
+fixture: ioctl(SIOCGIFFLAGS)
+fixture: ioctl(SIOCSIFFLAGS)
+fixture: ioctl(SIOCGIFINDEX)
+erlinit: configure_hostname
+erlinit: /etc/hostname not found
+erlinit: Env: 'HOME=/home/user0'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/srv/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erlexec'
+erlinit: Arg: 'erlexec'
+erlinit: Arg: '-config'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/sys.config'
+erlinit: Arg: '-boot'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
+erlinit: Arg: '-args_file'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
+erlinit: Launching erl...
+erlexec is sending signal to reboot
+erlinit: sigterm -> reboot
+erlinit: waiting 10000 ms for graceful shutdown
+erlinit: graceful shutdown detected
+erlinit: kill_all
+erlinit: Sending SIGTERM to all processes
+fixture: kill(-1, 15)
+fixture: sleep(1)
+erlinit: Sending SIGKILL to all processes
+fixture: kill(-1, 9)
+erlinit: Writing shutdown report to '/shutdown.txt'
+erlinit: unmount_all
+erlinit: unmounting tmpfs at /sys/fs/cgroup...
+fixture: umount("/sys/fs/cgroup")
+erlinit: unmounting tmpfs at /dev/shm...
+fixture: umount("/dev/shm")
+erlinit: unmounting devpts at /dev/pts...
+fixture: umount("/dev/pts")
+erlinit: unmounting proc at /proc...
+fixture: umount("/proc")
+erlinit: unmounting sysfs at /sys...
+fixture: umount("/sys")
+EOF

--- a/tests/fixture/erlinit_fixture.c
+++ b/tests/fixture/erlinit_fixture.c
@@ -214,8 +214,8 @@ OVERRIDE(int, open, (const char *pathname, int flags, ...))
         mode = 0;
     va_end(ap);
 
-    // Log to stderr
-    if (strcmp(pathname, "/dev/kmsg") == 0)
+    // Log to stderr if opened for write (read is stubbed)
+    if (strcmp(pathname, "/dev/kmsg") == 0 && (flags & (O_RDWR|O_WRONLY)))
         return dup(STDERR_FILENO);
 
     char new_path[PATH_MAX];


### PR DESCRIPTION
The shutdown report can be enabled by passing `--shutdown-report
<path>`. When enabled, `erlinit` will save information about why it is
either shutting down the system or rebooting. This report can be really
helpful when debugging unexplained reboots.