### PR TITLE
Remove cr characters from log messages

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -41,7 +41,7 @@ static int format_message(char **strp, const char *fmt, va_list ap)
         return -1;
     }
 
-    int rc = asprintf(strp, PROGRAM_NAME ": %s\r\n", msg);
+    int rc = asprintf(strp, PROGRAM_NAME ": %s\n", msg);
     free(msg);
 
     return rc;
@@ -91,14 +91,14 @@ void warn(const char *fmt, ...)
 
 void fatal(const char *fmt, ...)
 {
-    log_write("\r\n\r\nFATAL ERROR:\r\n", 18);
+    log_write("\n\nFATAL ERROR:\n", 18);
 
     va_list ap;
     va_start(ap, fmt);
     log_format(fmt, ap);
     va_end(ap);
 
-    log_write("\r\n\r\nCANNOT CONTINUE.\r\n", 22);
+    log_write("\n\nCANNOT CONTINUE.\n", 22);
 
     // Sleep so that the message can be printed
     sleep(1);


### PR DESCRIPTION
These were an artifact of when logging was done to stderr. Ever since
the switch to use the kernel log, the carriage return characters have
been unnecessary.

In the unlikely event that the kernel log is unavailable, the logger
will write to stderr and the lack of cr characters will result in poor
formatting, but I believe that the first course of action when this
happens is to fix the kernel log. Also, the message won't be pretty, but
it will still convey the issue.