### PR TITLE
Restrict operations on /dev

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -129,6 +129,7 @@ void setup_pseudo_filesystems()
     OK_OR_WARN(mount("sysfs", "/sys", "sysfs", MS_NOEXEC | MS_NOSUID | MS_NODEV, NULL), "Cannot mount /sys");
 
     // /dev should be automatically created/mounted by Linux
+    OK_OR_WARN(mount("devtmpfs", "/dev", "devtmpfs", MS_REMOUNT | MS_NOEXEC | MS_NOSUID, "size=1024k"), "Cannot remount /dev");
 
     // Create entries in /dev. Turn off the umask since we want the exact
     // permissions that we're specifying.

--- a/tests/001_cmdline_verbose
+++ b/tests/001_cmdline_verbose
@@ -14,6 +14,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/002_config_verbose
+++ b/tests/002_config_verbose
@@ -14,6 +14,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/003_run_release
+++ b/tests/003_run_release
@@ -20,6 +20,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/004_run_deep_release
+++ b/tests/004_run_deep_release
@@ -21,6 +21,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/005_run_strace
+++ b/tests/005_run_strace
@@ -26,6 +26,7 @@ erlinit: merged argv[2]=-s
 erlinit: merged argv[3]=/usr/bin/strace -f
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/006_env
+++ b/tests/006_env
@@ -16,6 +16,7 @@ erlinit: merged argv[2]=-e
 erlinit: merged argv[3]=LANG=en_US.UTF-8;LANGUAGE=en
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/007_multi_release_paths
+++ b/tests/007_multi_release_paths
@@ -22,6 +22,7 @@ erlinit: merged argv[2]=-r
 erlinit: merged argv[3]=/mnt/anotherplace:/srv/erlang
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/008_cmdline_verbose2
+++ b/tests/008_cmdline_verbose2
@@ -14,6 +14,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=--verbose
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -17,6 +17,7 @@ erlinit: merged argv[2]=--mount
 erlinit: merged argv[3]=/dev/mmcblk0p3:/root:vfat::
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/010_uniqueid
+++ b/tests/010_uniqueid
@@ -31,6 +31,7 @@ erlinit: merged argv[4]=--uniqueid-exec
 erlinit: merged argv[5]=/usr/bin/make-unique-id
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/011_etc_hostname
+++ b/tests/011_etc_hostname
@@ -18,6 +18,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/012_bad_option
+++ b/tests/012_bad_option
@@ -16,6 +16,7 @@ erlinit: merged argv[1]=-v
 erlinit: merged argv[2]=--unknown-option
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/013_bad_option2
+++ b/tests/013_bad_option2
@@ -16,6 +16,7 @@ erlinit: merged argv[1]=-v
 erlinit: merged argv[2]=-Z
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/014_tty_warning
+++ b/tests/014_tty_warning
@@ -29,6 +29,7 @@ erlinit: merged argv[3]=tty1
 erlinit: merged argv[4]=--warn-unused-tty
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/015_multi_mount
+++ b/tests/015_multi_mount
@@ -19,6 +19,7 @@ erlinit: merged argv[4]=--mount
 erlinit: merged argv[5]=/dev/mmcblk0p4:/mnt:ext4::
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/016_erlexec_boot_arg
+++ b/tests/016_erlexec_boot_arg
@@ -16,6 +16,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/017_erlexec_boot_arg_file
+++ b/tests/017_erlexec_boot_arg_file
@@ -16,6 +16,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/018_run_on_exit
+++ b/tests/018_run_on_exit
@@ -29,6 +29,7 @@ erlinit: merged argv[2]=--run-on-exit
 erlinit: merged argv[3]=/usr/bin/onexit
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/019_uid_and_gid
+++ b/tests/019_uid_and_gid
@@ -19,6 +19,7 @@ erlinit: merged argv[4]=--gid
 erlinit: merged argv[5]=200
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/020_pre_run_exec
+++ b/tests/020_pre_run_exec
@@ -29,6 +29,7 @@ erlinit: merged argv[2]=--pre-run-exec
 erlinit: merged argv[3]=/usr/bin/prerun
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/021_multi_boot_script
+++ b/tests/021_multi_boot_script
@@ -23,6 +23,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/022_pick_boot_script
+++ b/tests/022_pick_boot_script
@@ -27,6 +27,7 @@ erlinit: merged argv[2]=-b
 erlinit: merged argv[3]=/srv/erlang/releases/0.0.1/c
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/023_pick_boot_script2
+++ b/tests/023_pick_boot_script2
@@ -27,6 +27,7 @@ erlinit: merged argv[2]=-b
 erlinit: merged argv[3]=c
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/024_pick_missing_boot_script
+++ b/tests/024_pick_missing_boot_script
@@ -26,6 +26,7 @@ erlinit: merged argv[2]=--boot
 erlinit: merged argv[3]=missing_boot_script
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/025_start_erl_data
+++ b/tests/025_start_erl_data
@@ -32,6 +32,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/026_bad_start_erl_data
+++ b/tests/026_bad_start_erl_data
@@ -33,6 +33,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/027_bad_start_erl_data2
+++ b/tests/027_bad_start_erl_data2
@@ -33,6 +33,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/028_boot_script_preference
+++ b/tests/028_boot_script_preference
@@ -24,6 +24,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/029_funny_named_boot_script
+++ b/tests/029_funny_named_boot_script
@@ -24,6 +24,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/030_graceful_halt
+++ b/tests/030_graceful_halt
@@ -21,6 +21,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/031_graceful_reboot
+++ b/tests/031_graceful_reboot
@@ -21,6 +21,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/032_graceful_poweroff
+++ b/tests/032_graceful_poweroff
@@ -21,6 +21,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/033_ungraceful_halt
+++ b/tests/033_ungraceful_halt
@@ -21,6 +21,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/034_segfault
+++ b/tests/034_segfault
@@ -21,6 +21,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/035_working_directory
+++ b/tests/035_working_directory
@@ -23,6 +23,7 @@ erlinit: merged argv[2]=--working-directory
 erlinit: merged argv[3]=/tmp
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/036_bad_working_directory
+++ b/tests/036_bad_working_directory
@@ -24,6 +24,7 @@ erlinit: merged argv[2]=--working-directory
 erlinit: merged argv[3]=/doesntexist
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/037_graceful_timeout
+++ b/tests/037_graceful_timeout
@@ -23,6 +23,7 @@ erlinit: merged argv[2]=--graceful-shutdown-timeout
 erlinit: merged argv[3]=15000
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/038_consolidated_protocols
+++ b/tests/038_consolidated_protocols
@@ -24,6 +24,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/039_multi_consolidated
+++ b/tests/039_multi_consolidated
@@ -27,6 +27,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/040_update_clock
+++ b/tests/040_update_clock
@@ -17,6 +17,7 @@ erlinit: merged argv[1]=-v
 erlinit: merged argv[2]=--update-clock
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/041_uniqueid_whitespace
+++ b/tests/041_uniqueid_whitespace
@@ -31,6 +31,7 @@ erlinit: merged argv[4]=--uniqueid-exec
 erlinit: merged argv[5]=/usr/bin/make-unique-id
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/042_multiple_erts_w_start_erl
+++ b/tests/042_multiple_erts_w_start_erl
@@ -34,6 +34,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/043_bad_uniqueid
+++ b/tests/043_bad_uniqueid
@@ -32,6 +32,7 @@ erlinit: merged argv[4]=--uniqueid-exec
 erlinit: merged argv[5]=/usr/bin/make-unique-id
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/044_hostname_bad_chars
+++ b/tests/044_hostname_bad_chars
@@ -18,6 +18,7 @@ erlinit: merged argv[2]=--hostname-pattern
 erlinit: merged argv[3]=NERVES
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/045_hostname_bad_chars2
+++ b/tests/045_hostname_bad_chars2
@@ -18,6 +18,7 @@ erlinit: merged argv[2]=--hostname-pattern
 erlinit: merged argv[3]=N__ERVES
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/046_hostname_bad_chars3
+++ b/tests/046_hostname_bad_chars3
@@ -18,6 +18,7 @@ erlinit: merged argv[2]=--hostname-pattern
 erlinit: merged argv[3]=A-bc-de._g
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/047_alternate_exec
+++ b/tests/047_alternate_exec
@@ -33,6 +33,7 @@ erlinit: merged argv[2]=--alternate-exec
 erlinit: merged argv[3]=/usr/bin/altexec
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/048_alternate_exec_multiargs
+++ b/tests/048_alternate_exec_multiargs
@@ -33,6 +33,7 @@ erlinit: merged argv[2]=--alternate-exec
 erlinit: merged argv[3]=/usr/bin/altexec 1 2 3
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/049_alternate_exec_exec
+++ b/tests/049_alternate_exec_exec
@@ -37,6 +37,7 @@ erlinit: merged argv[2]=--alternate-exec
 erlinit: merged argv[3]=/usr/bin/altexec 1 2 exec 3
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/050_release_include_erts
+++ b/tests/050_release_include_erts
@@ -43,6 +43,7 @@ erlinit: merged argv[3]=/usr/lib/erelease
 erlinit: merged argv[4]=--release-include-erts
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/051_rootdisk_exists
+++ b/tests/051_rootdisk_exists
@@ -20,6 +20,7 @@ erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/052_configure_tty
+++ b/tests/052_configure_tty
@@ -17,6 +17,7 @@ erlinit: merged argv[2]=--tty-options
 erlinit: merged argv[3]=115200n8
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/053_getpwuid_failure
+++ b/tests/053_getpwuid_failure
@@ -17,6 +17,7 @@ erlinit: merged argv[2]=--uid
 erlinit: merged argv[3]=1
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/054_shutdown_report
+++ b/tests/054_shutdown_report
@@ -51,6 +51,7 @@ erlinit: merged argv[2]=--shutdown-report
 erlinit: merged argv[3]=/shutdown.txt
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)

--- a/tests/055_pivot_root_on_overlayfs
+++ b/tests/055_pivot_root_on_overlayfs
@@ -25,6 +25,7 @@ fixture: mount("/dev", "/mnt/.merged/dev", "tmpfs", 8192, data)
 erlinit: Could not change directory to /mnt/.merged: No such file or directory
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
 fixture: mkdir("/dev/pts", 755)
 fixture: mkdir("/dev/shm", 1777)
 fixture: mount("devpts", "/dev/pts", "devpts", 10, data)


### PR DESCRIPTION
Remount `/dev` to set noexec, nosuid, and limit the max size to 1MB.
Previously it was possible to save large files to `/dev` and potentially
use up a lot of memory since it's a tmpfs. While it's easy to remount
`/dev` and undo this, this should hopefully make one think more before
misusing `/dev`.

Before:

```
devtmpfs on /dev type devtmpfs (rw,relatime,size=230036k,nr_inodes=57509,mode=755)
```

After:

```
devtmpfs on /dev type devtmpfs (rw,nosuid,noexec,relatime,size=1024k,nr_inodes=57509,mode=755)
```

For comparison, here is `/dev` on an Ubuntu desktop installation:

```
udev on /dev type devtmpfs (rw,nosuid,noexec,relatime,size=16341024k,nr_inodes=4085256,mode=755)
```