### PR TITLE
Test for the rootfs based on the source

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -166,7 +166,7 @@ void unmount_all()
         // Whitelist directories that don't unmount or
         // remount immediately (rootfs)
         if (strcmp(mounts[i].source, "devtmpfs") == 0 ||
-                strcmp(mounts[i].target, "/") == 0)
+                strcmp(mounts[i].source, "/dev/root") == 0)
             continue;
 
         debug("unmounting %s at %s...", mounts[i].source, mounts[i].target);

--- a/tests/run_tests_impl.sh
+++ b/tests/run_tests_impl.sh
@@ -95,10 +95,10 @@ run() {
 
     # Fake mounts
     cat >$WORK/proc/mounts << EOF
+/dev/root / squashfs ro,relatime 0 0
 sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
 proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
 devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0
-/dev/mmcblk0p2 / squashfs ro,relatime 0 0
 tmpfs /dev/shm tmpfs rw,nosuid,nodev 0 0
 tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec,mode=755 0 0
 EOF


### PR DESCRIPTION
This removes error messages when trying to unmount the rootfs from other
directories. This currently only occurs when using overlay filesystems,
but it seems like the more correct way of detecting the root filesystem
anyway.