### PR TITLE
Add experimental writable rootfs feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ The following lists the options:
 
 --working_directory <path>
     Set the working directory
+
+--x-pivot-root-on-overlayfs
+    This enables support for making a read-only root filesystem writable using
+    an overlayfs. It is experimental and the option will change.
 ```
 
 ## Rebooting or hanging when the Erlang VM exits

--- a/src/compat/compat.c
+++ b/src/compat/compat.c
@@ -59,3 +59,9 @@ int sigprocmask_noop(int how, const sigset_t *restrict set, sigset_t *restrict o
     return 0;
 }
 
+int pivot_root(const char *new_root, const char *put_old)
+{
+    (void) new_root;
+    (void) put_old;
+    return 0;
+}

--- a/src/erlinit.c
+++ b/src/erlinit.c
@@ -947,6 +947,10 @@ int main(int argc, char *argv[])
     for (i = 0; i < merged_argc; i++)
         debug("merged argv[%d]=%s", i, merged_argv[i]);
 
+    // Set up experimental writable file system overlay
+    if (options.x_pivot_root_on_overlayfs)
+        pivot_root_on_overlayfs();
+
     // Mount /dev, /proc and /sys
     setup_pseudo_filesystems();
 

--- a/src/erlinit.h
+++ b/src/erlinit.h
@@ -82,6 +82,7 @@ struct erlinit_options {
     int update_clock;
     char *tty_options;
     char *shutdown_report;
+    int x_pivot_root_on_overlayfs;
 };
 
 extern struct erlinit_options options;
@@ -114,6 +115,7 @@ void setup_networking(void);
 void configure_hostname(void);
 
 // Filesystems
+void pivot_root_on_overlayfs(void);
 void setup_pseudo_filesystems(void);
 void create_rootdisk_symlinks(void);
 void mount_filesystems(void);

--- a/src/fs.c
+++ b/src/fs.c
@@ -166,7 +166,7 @@ void unmount_all()
         // Whitelist directories that don't unmount or
         // remount immediately (rootfs)
         if (strcmp(mounts[i].source, "devtmpfs") == 0 ||
-                strcmp(mounts[i].target, "/") == 0)
+                strcmp(mounts[i].source, "/dev/root") == 0)
             continue;
 
         debug("unmounting %s at %s...", mounts[i].source, mounts[i].target);

--- a/src/options.c
+++ b/src/options.c
@@ -53,7 +53,8 @@ struct erlinit_options options = {
     .uid = 0,
     .graceful_shutdown_timeout_ms = 10000,
     .update_clock = 0,
-    .shutdown_report = NULL
+    .shutdown_report = NULL,
+    .x_pivot_root_on_overlayfs = 0
 };
 
 enum erlinit_option_value {
@@ -88,7 +89,10 @@ enum erlinit_option_value {
     OPT_UPDATE_CLOCK,
     OPT_RELEASE_INCLUDE_ERTS,
     OPT_TTY_OPTIONS,
-    OPT_SHUTDOWN_REPORT
+    OPT_SHUTDOWN_REPORT,
+
+    // Experimental
+    OPT_X_PIVOT_ROOT_ON_OVERLAYFS
 };
 
 static struct option long_options[] = {
@@ -119,6 +123,7 @@ static struct option long_options[] = {
     {"update-clock", no_argument, 0, OPT_UPDATE_CLOCK },
     {"tty-options", required_argument, 0, OPT_TTY_OPTIONS},
     {"shutdown-report", required_argument, 0, OPT_SHUTDOWN_REPORT},
+    {"x-pivot-root-on-overlayfs", no_argument, 0, OPT_X_PIVOT_ROOT_ON_OVERLAYFS},
     {0,     0,      0, 0 }
 };
 
@@ -227,6 +232,9 @@ void parse_args(int argc, char *argv[])
             break;
         case OPT_SHUTDOWN_REPORT: // --shutdown-report /root/shutdown.txt
             SET_STRING_OPTION(options.shutdown_report);
+            break;
+        case OPT_X_PIVOT_ROOT_ON_OVERLAYFS: // --x-pivot-root-on-overlayfs
+            options.x_pivot_root_on_overlayfs = 1;
             break;
         default:
             // getopt prints a warning, so we don't have to

--- a/tests/055_pivot_root_on_overlayfs
+++ b/tests/055_pivot_root_on_overlayfs
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+#
+# Test that the pivot root on an overlayfs feature "works"
+#
+
+cat >"$CMDLINE_FILE" <<EOF
+-v --x-pivot-root-on-overlayfs
+EOF
+
+cat >"$EXPECTED" <<EOF
+erlinit: cmdline argc=3, merged argc=3
+erlinit: merged argv[0]=/sbin/init
+erlinit: merged argv[1]=-v
+erlinit: merged argv[2]=--x-pivot-root-on-overlayfs
+erlinit: pivot_root_on_overlayfs
+fixture: mount("", "/mnt", "tmpfs", 0, data)
+fixture: mkdir("/mnt/.merged", 755)
+fixture: mkdir("/mnt/.upper", 755)
+fixture: mkdir("/mnt/.work", 755)
+fixture: mount("", "/mnt/.merged", "overlay", 0, data)
+fixture: mkdir("/mnt/.merged/dev", 755)
+erlinit: Cannot create /mnt/.merged/dev
+fixture: mount("/dev", "/mnt/.merged/dev", "tmpfs", 8192, data)
+erlinit: Could not change directory to /mnt/.merged: No such file or directory
+fixture: mount("proc", "/proc", "proc", 14, data)
+fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mkdir("/dev/pts", 755)
+fixture: mkdir("/dev/shm", 1777)
+fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
+fixture: symlink("/dev/mmcblk0","/dev/rootdisk0")
+fixture: symlink("/dev/mmcblk0p4","/dev/rootdisk0p4")
+fixture: symlink("/dev/mmcblk0p3","/dev/rootdisk0p3")
+fixture: symlink("/dev/mmcblk0p2","/dev/rootdisk0p2")
+fixture: symlink("/dev/mmcblk0p1","/dev/rootdisk0p1")
+erlinit: set_ctty
+fixture: setsid()
+fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
+fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
+erlinit: find_release
+erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
+erlinit: setup_environment
+erlinit: setup_networking
+fixture: ioctl(SIOCGIFFLAGS)
+fixture: ioctl(SIOCSIFFLAGS)
+fixture: ioctl(SIOCGIFINDEX)
+erlinit: configure_hostname
+erlinit: /etc/hostname not found
+erlinit: Env: 'HOME=/home/user0'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erlexec'
+erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
+erlinit: Launching erl...
+Hello from erlexec
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: Sending SIGTERM to all processes
+fixture: kill(-1, 15)
+fixture: sleep(1)
+erlinit: Sending SIGKILL to all processes
+fixture: kill(-1, 9)
+erlinit: unmount_all
+erlinit: unmounting tmpfs at /sys/fs/cgroup...
+fixture: umount("/sys/fs/cgroup")
+erlinit: unmounting tmpfs at /dev/shm...
+fixture: umount("/dev/shm")
+erlinit: unmounting devpts at /dev/pts...
+fixture: umount("/dev/pts")
+erlinit: unmounting proc at /proc...
+fixture: umount("/proc")
+erlinit: unmounting sysfs at /sys...
+fixture: umount("/sys")
+EOF
+

--- a/tests/run_tests_impl.sh
+++ b/tests/run_tests_impl.sh
@@ -95,10 +95,10 @@ run() {
 
     # Fake mounts
     cat >$WORK/proc/mounts << EOF
+/dev/root / squashfs ro,relatime 0 0
 sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
 proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
 devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0
-/dev/mmcblk0p2 / squashfs ro,relatime 0 0
 tmpfs /dev/shm tmpfs rw,nosuid,nodev 0 0
 tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec,mode=755 0 0
 EOF


### PR DESCRIPTION
By specifying enabling `CONFIG_OVERLAY_FS` in the kernel and passing `--x-pivot-root-on-overlayfs` to `erlinit`, `erlinit` will use it to make a normally read-only filesystem writable. This means that you can do release updates and other experimentation on Nerves without hacking Erlang load paths. Everything that's written will be lost on a reboot since the writable part isn't persisted. 

I'd really like to change how this feature is configured to make it more flexible, but I don't have time. I understand that several people want to experiment with it and this seems good enough to do that and get feedback. Please don't get attached to the option. I'd like to update this to be more generic, but that requires some thought.