### PR TITLE
Allow for longer version names

### DIFF
--- a/src/erlinit.c
+++ b/src/erlinit.c
@@ -331,9 +331,11 @@ static int read_start_erl(const char *releases_dir, char **erts_version, char **
         return 0;
     }
 
-    char erts_string[17];
-    char rel_string[17];
-    if (fscanf(fp, "%16s %16s", erts_string, rel_string) != 2) {
+#define MAX_VERSION_AND_RELEASE_NAMES 32
+    char erts_string[MAX_VERSION_AND_RELEASE_NAMES + 1];
+    char rel_string[MAX_VERSION_AND_RELEASE_NAMES + 1];
+    if (fscanf(fp, "%" xstr(MAX_VERSION_AND_RELEASE_NAMES) "s %" xstr(MAX_VERSION_AND_RELEASE_NAMES) "s",
+               erts_string, rel_string) != 2) {
         warn("%s doesn't contain expected contents. Skipping.", start_erl_path);
         free(start_erl_path);
         fclose(fp);

--- a/tests/026_bad_start_erl_data
+++ b/tests/026_bad_start_erl_data
@@ -24,7 +24,7 @@ for RPATH in $RELEASE_PATH1 $RELEASE_PATH2 $RELEASE_PATH3; do
 done
 
 cat >$WORK/srv/erlang/releases/start_erl.data <<EOF
-8.31234500320020 0.0.21290384701298340129837019287
+8.31234500320020 0.0.56789012345678901234567890123456789012345678901234567890
 EOF
 
 cat >"$EXPECTED" <<EOF
@@ -47,7 +47,7 @@ fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
 erlinit: find_release
-erlinit: start_erl.data specifies 0.0.212903847012, but /srv/erlang/releases/0.0.212903847012 isn't a directory
+erlinit: start_erl.data specifies 0.0.5678901234567890123456789012, but /srv/erlang/releases/0.0.5678901234567890123456789012 isn't a directory
 erlinit: Using release in /srv/erlang/releases/0.0.3.
 erlinit: find_sys_config
 erlinit: find_vm_args


### PR DESCRIPTION
It turns out that 16 characters can be too few. Double the size.