### PR TITLE
set core limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ The following lists the options:
 --hang-on-fatal
     Hang if a fatal error is detected in erlinit.
 
+-l, --limits <resource:soft:hard>
+    Set resource limits. See prlimit(1) and prlimit(2) for available resources.
+    Specify multiple times to set more than one resource's limits.
+
 -m, --mount <dev:path:type:flags:options>
     Mount the specified path. See mount(8) and fstab(5) for fields
     Specify multiple times for more than one path to mount.

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -62,4 +62,13 @@ int sigprocmask_noop(int how, const sigset_t *restrict set, sigset_t *restrict o
 #define SIOCGIFINDEX SIOCGIFMTU
 #define ifr_ifindex         ifr_ifru.ifru_mtu
 
+// Updates to "sys/resource.h"
+// Non-OSX RLIMIT defines here are well above anything valid
+#define RLIMIT_NICE       100
+#define RLIMIT_SIGPENDING 101
+#define RLIMIT_RTPRIO     102
+#define RLIMIT_LOCKS      103
+#define RLIMIT_RTTIME     104
+#define RLIMIT_MSGQUEUE   105
+
 #endif

--- a/src/erlinit.c
+++ b/src/erlinit.c
@@ -37,6 +37,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <sys/reboot.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <sys/resource.h>
 #include <pwd.h>
 
 struct erl_run_info {
@@ -963,6 +964,9 @@ int main(int argc, char *argv[])
     // Fix the terminal settings so output goes to the right
     // terminal and the CTRL keys work in the shell..
     set_ctty();
+
+    // Set resource limits. This has to be done before fork.
+    create_limits();
 
     struct erlinit_exit_info exit_info;
     fork_and_wait(&exit_info);

--- a/src/erlinit.h
+++ b/src/erlinit.h
@@ -82,6 +82,7 @@ struct erlinit_options {
     int update_clock;
     char *tty_options;
     char *shutdown_report;
+    char *limits;
     int x_pivot_root_on_overlayfs;
 };
 
@@ -120,6 +121,9 @@ void setup_pseudo_filesystems(void);
 void create_rootdisk_symlinks(void);
 void mount_filesystems(void);
 void unmount_all(void);
+
+// Limits
+void create_limits(void);
 
 // Terminal
 void set_ctty(void);

--- a/src/limit.c
+++ b/src/limit.c
@@ -1,0 +1,95 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2021 Frank Hunleth
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "erlinit.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+
+static rlim_t str_to_limit(const char *s)
+{
+    // empty string means infinity
+    if (strcmp(s, "unlimited") == 0 || strlen(s) == 0)
+        return RLIM_INFINITY;
+    else
+        return strtoul(s, NULL, 10);
+}
+
+static int str_to_resource(const char *s)
+{
+    struct entry {
+        const char *str;
+        int value;
+    };
+    static const struct entry table[] = {
+        {"core", RLIMIT_CORE},
+        {"data", RLIMIT_DATA},
+        {"nice", RLIMIT_NICE},
+        {"fsize", RLIMIT_FSIZE},
+        {"sigpending", RLIMIT_SIGPENDING},
+        {"memlock", RLIMIT_MEMLOCK},
+        {"rss", RLIMIT_RSS},
+        {"nofile", RLIMIT_NOFILE},
+        {"msgqueue", RLIMIT_MSGQUEUE},
+        {"rtprio", RLIMIT_RTPRIO},
+        {"stack", RLIMIT_STACK},
+        {"cpu", RLIMIT_CPU},
+        {"nproc", RLIMIT_NPROC},
+        {"as", RLIMIT_AS},
+        {"locks", RLIMIT_LOCKS},
+        {"rttime", RLIMIT_RTTIME},
+        {NULL, 0}
+    };
+
+    for (const struct entry *i = table; i->str; ++i) {
+        if (strcmp(s, i->str) == 0)
+            return i->value;
+    }
+
+    warn("Unrecognized resource %s", s);
+    return -1;
+}
+
+void create_limits()
+{
+    char *temp = options.limits;
+    while (temp) {
+        const char *resource_name = strsep(&temp, ":");
+        const char *soft = strsep(&temp, ":");
+        const char *hard = strsep(&temp, ";"); // multi-limit separator
+        if (resource_name && soft && hard) {
+            int resource = str_to_resource(resource_name);
+            struct rlimit limit;
+            limit.rlim_cur = str_to_limit(soft);
+            limit.rlim_max = str_to_limit(hard);
+            if (setrlimit(resource, &limit) != 0)
+                warn("could not set limits %s");
+
+        } else {
+            warn("Invalid parameter to -l. Expecting 3 colon-separated fields");
+        }
+    }
+}

--- a/src/options.c
+++ b/src/options.c
@@ -54,6 +54,7 @@ struct erlinit_options options = {
     .graceful_shutdown_timeout_ms = 10000,
     .update_clock = 0,
     .shutdown_report = NULL,
+    .limits = NULL,
     .x_pivot_root_on_overlayfs = 0
 };
 
@@ -66,6 +67,7 @@ enum erlinit_option_value {
     OPT_UNIQUEID_EXEC= 'd',
     OPT_ENV = 'e',
     OPT_HANG_ON_EXIT = 'h',
+    OPT_LIMIT = 'l',
     OPT_MOUNT = 'm',
     OPT_HOSTNAME_PATTERN = 'n',
     OPT_RELEASE_PATH = 'r',
@@ -123,6 +125,7 @@ static struct option long_options[] = {
     {"update-clock", no_argument, 0, OPT_UPDATE_CLOCK },
     {"tty-options", required_argument, 0, OPT_TTY_OPTIONS},
     {"shutdown-report", required_argument, 0, OPT_SHUTDOWN_REPORT},
+    {"limits", required_argument, 0, OPT_LIMIT},
     {"x-pivot-root-on-overlayfs", no_argument, 0, OPT_X_PIVOT_ROOT_ON_OVERLAYFS},
     {0,     0,      0, 0 }
 };
@@ -145,7 +148,7 @@ void parse_args(int argc, char *argv[])
         int option_index;
         int opt = getopt_long(argc,
                               argv,
-                              "b:c:d:e:hm:n:r:s:tv",
+                              "b:c:d:e:hl:m:n:r:s:tv",
                               long_options,
                               &option_index);
         if (opt < 0)
@@ -181,6 +184,9 @@ void parse_args(int argc, char *argv[])
             break;
         case OPT_POWEROFF_ON_FATAL: // --poweroff-on-fatal
             options.fatal_reboot_cmd = LINUX_REBOOT_CMD_POWER_OFF;
+            break;
+        case OPT_LIMIT: // --limit core:unlimited:unlimited
+            APPEND_STRING_OPTION(options.limits, ';');
             break;
         case OPT_MOUNT: // --mount /dev/mmcblk0p3:/root:vfat::
             APPEND_STRING_OPTION(options.extra_mounts, ';');

--- a/tests/056_setrlimit
+++ b/tests/056_setrlimit
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+#
+# Test that specifying -v on the command line works
+#
+
+cat >"$CMDLINE_FILE" <<EOF
+-v
+--limit core:unlimited:unlimited
+EOF
+
+cat >"$EXPECTED" <<EOF
+erlinit: cmdline argc=4, merged argc=4
+erlinit: merged argv[0]=/sbin/init
+erlinit: merged argv[1]=-v
+erlinit: merged argv[2]=--limit
+erlinit: merged argv[3]=core:unlimited:unlimited
+fixture: mount("proc", "/proc", "proc", 14, data)
+fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
+fixture: mkdir("/dev/pts", 755)
+fixture: mkdir("/dev/shm", 1777)
+fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
+fixture: symlink("/dev/mmcblk0","/dev/rootdisk0")
+fixture: symlink("/dev/mmcblk0p4","/dev/rootdisk0p4")
+fixture: symlink("/dev/mmcblk0p3","/dev/rootdisk0p3")
+fixture: symlink("/dev/mmcblk0p2","/dev/rootdisk0p2")
+fixture: symlink("/dev/mmcblk0p1","/dev/rootdisk0p1")
+erlinit: set_ctty
+fixture: setsid()
+fixture: setrlimit(core, unlimited, unlimited)
+fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
+fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
+erlinit: find_release
+erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
+erlinit: setup_environment
+erlinit: setup_networking
+fixture: ioctl(SIOCGIFFLAGS)
+fixture: ioctl(SIOCSIFFLAGS)
+fixture: ioctl(SIOCGIFINDEX)
+erlinit: configure_hostname
+erlinit: /etc/hostname not found
+erlinit: Env: 'HOME=/home/user0'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erlexec'
+erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
+erlinit: Launching erl...
+Hello from erlexec
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: Sending SIGTERM to all processes
+fixture: kill(-1, 15)
+fixture: sleep(1)
+erlinit: Sending SIGKILL to all processes
+fixture: kill(-1, 9)
+erlinit: unmount_all
+erlinit: unmounting tmpfs at /sys/fs/cgroup...
+fixture: umount("/sys/fs/cgroup")
+erlinit: unmounting tmpfs at /dev/shm...
+fixture: umount("/dev/shm")
+erlinit: unmounting devpts at /dev/pts...
+fixture: umount("/dev/pts")
+erlinit: unmounting proc at /proc...
+fixture: umount("/proc")
+erlinit: unmounting sysfs at /sys...
+fixture: umount("/sys")
+EOF

--- a/tests/057_setrlimit_multiple
+++ b/tests/057_setrlimit_multiple
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+#
+# Test that specifying -v on the command line works
+#
+
+cat >"$CMDLINE_FILE" <<EOF
+-v --limit core:456:unlimited --limit data:unlimited:123
+EOF
+
+cat >"$EXPECTED" <<EOF
+erlinit: cmdline argc=6, merged argc=6
+erlinit: merged argv[0]=/sbin/init
+erlinit: merged argv[1]=-v
+erlinit: merged argv[2]=--limit
+erlinit: merged argv[3]=core:456:unlimited
+erlinit: merged argv[4]=--limit
+erlinit: merged argv[5]=data:unlimited:123
+fixture: mount("proc", "/proc", "proc", 14, data)
+fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
+fixture: mkdir("/dev/pts", 755)
+fixture: mkdir("/dev/shm", 1777)
+fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
+fixture: symlink("/dev/mmcblk0","/dev/rootdisk0")
+fixture: symlink("/dev/mmcblk0p4","/dev/rootdisk0p4")
+fixture: symlink("/dev/mmcblk0p3","/dev/rootdisk0p3")
+fixture: symlink("/dev/mmcblk0p2","/dev/rootdisk0p2")
+fixture: symlink("/dev/mmcblk0p1","/dev/rootdisk0p1")
+erlinit: set_ctty
+fixture: setsid()
+fixture: setrlimit(core, 456, unlimited)
+fixture: setrlimit(data, unlimited, 123)
+fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
+fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
+erlinit: find_release
+erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
+erlinit: setup_environment
+erlinit: setup_networking
+fixture: ioctl(SIOCGIFFLAGS)
+fixture: ioctl(SIOCSIFFLAGS)
+fixture: ioctl(SIOCGIFINDEX)
+erlinit: configure_hostname
+erlinit: /etc/hostname not found
+erlinit: Env: 'HOME=/home/user0'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erlexec'
+erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
+erlinit: Launching erl...
+Hello from erlexec
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: Sending SIGTERM to all processes
+fixture: kill(-1, 15)
+fixture: sleep(1)
+erlinit: Sending SIGKILL to all processes
+fixture: kill(-1, 9)
+erlinit: unmount_all
+erlinit: unmounting tmpfs at /sys/fs/cgroup...
+fixture: umount("/sys/fs/cgroup")
+erlinit: unmounting tmpfs at /dev/shm...
+fixture: umount("/dev/shm")
+erlinit: unmounting devpts at /dev/pts...
+fixture: umount("/dev/pts")
+erlinit: unmounting proc at /proc...
+fixture: umount("/proc")
+erlinit: unmounting sysfs at /sys...
+fixture: umount("/sys")
+EOF


### PR DESCRIPTION
This first iteration hard codes CORE limits to the erlang VM (and any other processes).
this is required for creating coredumps of the VM