### PR TITLE
Change echo to printf so that newlines work

### DIFF
--- a/tests/041_uniqueid_whitespace
+++ b/tests/041_uniqueid_whitespace
@@ -17,7 +17,7 @@ EOF
 cat >$WORK/usr/bin/make-unique-id <<EOF
 #!/bin/sh
 
-echo "  4\n888888888\n\n"
+printf "  4\n888888888\n\n"
 EOF
 chmod +x $WORK/usr/bin/make-unique-id
 


### PR DESCRIPTION
Fixes this error:

```
Running 041_uniqueid_whitespace...
33,34c33,34
< erlinit: Hostname: nerves-4n888888888nn
< fixture: sethostname("nerves-4n888888888nn", 20)
---
> erlinit: Hostname: nerves-4
> fixture: sethostname("nerves-4", 8)
Test 041_uniqueid_whitespace failed!
```
