### PR TITLE
Make shebang lines consistent

### DIFF
--- a/tests/001_cmdline_verbose
+++ b/tests/001_cmdline_verbose
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that specifying -v on the command line works

--- a/tests/002_config_verbose
+++ b/tests/002_config_verbose
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that specifying -v in the config file works

--- a/tests/003_run_release
+++ b/tests/003_run_release
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that starting up a Erlang/OTP release works

--- a/tests/004_run_deep_release
+++ b/tests/004_run_deep_release
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that starting up an Erlang/OTP release that's underneath a directory works

--- a/tests/005_run_strace
+++ b/tests/005_run_strace
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that requesting that strace be run does the right thing
@@ -12,7 +12,7 @@ cat >"$CONFIG" <<EOF
 EOF
 
 cat >$WORK/usr/bin/strace <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo Hello from strace 1>&2
 EOF

--- a/tests/006_env
+++ b/tests/006_env
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that a nearly parameterless run of erlexec works

--- a/tests/007_multi_release_paths
+++ b/tests/007_multi_release_paths
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that starting up a Erlang/OTP release works

--- a/tests/008_cmdline_verbose2
+++ b/tests/008_cmdline_verbose2
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that specifying --verbose on the command line works

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test whether the mount option works. We can't easily test

--- a/tests/010_uniqueid
+++ b/tests/010_uniqueid
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that calling out to a unique id generator does the right thing
@@ -15,7 +15,7 @@ cat >"$CONFIG" <<EOF
 EOF
 
 cat >"$WORK/usr/bin/make-unique-id" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo "0042"
 EOF

--- a/tests/011_etc_hostname
+++ b/tests/011_etc_hostname
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that /etc/hostname is read

--- a/tests/012_bad_option
+++ b/tests/012_bad_option
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that specifying an unknown option results in a warning

--- a/tests/013_bad_option2
+++ b/tests/013_bad_option2
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that specifying an unknown option results in a warning

--- a/tests/014_tty_warning
+++ b/tests/014_tty_warning
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that when the kernel is printing output on multiple ttys that warnings

--- a/tests/015_multi_mount
+++ b/tests/015_multi_mount
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test whether the mount option works. We can't easily test

--- a/tests/016_erlexec_boot_arg
+++ b/tests/016_erlexec_boot_arg
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that the boot_arg parameter for erlexec works

--- a/tests/017_erlexec_boot_arg_file
+++ b/tests/017_erlexec_boot_arg_file
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that the boot_arg parameter for erlexec works

--- a/tests/018_run_on_exit
+++ b/tests/018_run_on_exit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that running a program when the Erlang VM exits works
@@ -9,7 +9,7 @@ cat >"$CMDLINE_FILE" <<EOF
 EOF
 
 cat >$WORK/usr/bin/onexit <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo Hello from onexit 1>&2
 EOF

--- a/tests/019_uid_and_gid
+++ b/tests/019_uid_and_gid
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test whether the mount option works. We can't easily test

--- a/tests/020_pre_run_exec
+++ b/tests/020_pre_run_exec
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that running a program when the Erlang VM exits works
@@ -9,7 +9,7 @@ cat >"$CMDLINE_FILE" <<EOF
 EOF
 
 cat >$WORK/usr/bin/prerun <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo Hello from prerun 1>&2
 EOF

--- a/tests/021_multi_boot_script
+++ b/tests/021_multi_boot_script
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that automatically picking a boot script picks the first one

--- a/tests/022_pick_boot_script
+++ b/tests/022_pick_boot_script
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Check that specifying a boot script works

--- a/tests/023_pick_boot_script2
+++ b/tests/023_pick_boot_script2
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Check that specifying a boot script works

--- a/tests/024_pick_missing_boot_script
+++ b/tests/024_pick_missing_boot_script
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that automatically picking a boot script when one can't be found

--- a/tests/025_start_erl_data
+++ b/tests/025_start_erl_data
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that the start_erl.data file is read when picking a release to run.

--- a/tests/026_bad_start_erl_data
+++ b/tests/026_bad_start_erl_data
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that the start_erl.data file that has contents that would

--- a/tests/027_bad_start_erl_data2
+++ b/tests/027_bad_start_erl_data2
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that the start_erl.data file that has contents that would

--- a/tests/028_boot_script_preference
+++ b/tests/028_boot_script_preference
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Check that the automatically picked boot script prefers

--- a/tests/029_funny_named_boot_script
+++ b/tests/029_funny_named_boot_script
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Check that if <release>.boot doesn't exist that another boot

--- a/tests/030_graceful_halt
+++ b/tests/030_graceful_halt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that gracefully halting the system works.

--- a/tests/031_graceful_reboot
+++ b/tests/031_graceful_reboot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that gracefully rebooting the system works.

--- a/tests/032_graceful_poweroff
+++ b/tests/032_graceful_poweroff
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that gracefully powering off works.

--- a/tests/033_ungraceful_halt
+++ b/tests/033_ungraceful_halt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that a halt that hangs the system gets handled.

--- a/tests/034_segfault
+++ b/tests/034_segfault
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that a segfault is caught and handled appropriately

--- a/tests/035_working_directory
+++ b/tests/035_working_directory
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that changing the working directory works

--- a/tests/036_bad_working_directory
+++ b/tests/036_bad_working_directory
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that changing the working directory to something

--- a/tests/037_graceful_timeout
+++ b/tests/037_graceful_timeout
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that gracefully halting the system works.

--- a/tests/038_consolidated_protocols
+++ b/tests/038_consolidated_protocols
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that changing the working directory works

--- a/tests/039_multi_consolidated
+++ b/tests/039_multi_consolidated
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that changing the working directory works

--- a/tests/040_update_clock
+++ b/tests/040_update_clock
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that specifying --update-clock in the config file is

--- a/tests/041_uniqueid_whitespace
+++ b/tests/041_uniqueid_whitespace
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that calling out to a unique id generator does the right thing
@@ -15,7 +15,7 @@ cat >"$CONFIG" <<EOF
 EOF
 
 cat >$WORK/usr/bin/make-unique-id <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 
 printf "  4\n888888888\n\n"
 EOF

--- a/tests/042_multiple_erts_w_start_erl
+++ b/tests/042_multiple_erts_w_start_erl
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that the start_erl.data file is read when picking a release to run.

--- a/tests/043_bad_uniqueid
+++ b/tests/043_bad_uniqueid
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that calling out to a unique id generator that fails still boots
@@ -15,7 +15,7 @@ cat >"$CONFIG" <<EOF
 EOF
 
 cat >$WORK/usr/bin/make-unique-id <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo "ERROR ROAR bad bad"
 exit 1

--- a/tests/044_hostname_bad_chars
+++ b/tests/044_hostname_bad_chars
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that specifying a hostname with bad characters gets fixed

--- a/tests/045_hostname_bad_chars2
+++ b/tests/045_hostname_bad_chars2
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that specifying a hostname with bad characters gets fixed

--- a/tests/046_hostname_bad_chars3
+++ b/tests/046_hostname_bad_chars3
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that specifying a hostname with bad characters gets fixed

--- a/tests/047_alternate_exec
+++ b/tests/047_alternate_exec
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that running a program to wrap the call to the Erlang VM works
@@ -9,7 +9,7 @@ cat >"$CMDLINE_FILE" <<EOF
 EOF
 
 cat >$WORK/usr/bin/altexec <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo Hello from altexec 1>&2
 echo Args: 1>&2

--- a/tests/048_alternate_exec_multiargs
+++ b/tests/048_alternate_exec_multiargs
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that running a program to wrap the call to the Erlang VM works
@@ -9,7 +9,7 @@ cat >"$CONFIG" <<EOF
 EOF
 
 cat >$WORK/usr/bin/altexec <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo Hello from altexec 1>&2
 echo Args: 1>&2

--- a/tests/049_alternate_exec_exec
+++ b/tests/049_alternate_exec_exec
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that calling exec with --alternate-exec merges args
@@ -13,7 +13,7 @@ cat >"$CONFIG" <<EOF
 EOF
 
 cat >$WORK/usr/bin/altexec <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo Hello from altexec 1>&2
 echo Args: 1>&2

--- a/tests/050_release_include_erts
+++ b/tests/050_release_include_erts
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that starting up a Erlang/OTP release using an embedded ERTS

--- a/tests/051_rootdisk_exists
+++ b/tests/051_rootdisk_exists
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that if the rootdisk* files exist that erlinit doesn't

--- a/tests/052_configure_tty
+++ b/tests/052_configure_tty
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test the --tty-option can set 115200n8

--- a/tests/053_getpwuid_failure
+++ b/tests/053_getpwuid_failure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that if getpwuid fails to find the home directory that

--- a/tests/054_shutdown_report
+++ b/tests/054_shutdown_report
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that saving a shutdown report works.

--- a/tests/055_pivot_root_on_overlayfs
+++ b/tests/055_pivot_root_on_overlayfs
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that the pivot root on an overlayfs feature "works"

--- a/tests/056_setrlimit
+++ b/tests/056_setrlimit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that specifying -v on the command line works

--- a/tests/057_setrlimit_multiple
+++ b/tests/057_setrlimit_multiple
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Test that specifying -v on the command line works

--- a/tests/fake_erlexec
+++ b/tests/fake_erlexec
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo "Hello from erlexec" 1>&2

--- a/tests/fake_erlexec.halt
+++ b/tests/fake_erlexec.halt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo "erlexec is sending signal to halt" 1>&2
 

--- a/tests/fake_erlexec.poweroff
+++ b/tests/fake_erlexec.poweroff
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo "erlexec is sending signal to power off" 1>&2
 

--- a/tests/fake_erlexec.pwd
+++ b/tests/fake_erlexec.pwd
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo "Hello from erlexec in $PWD" 1>&2

--- a/tests/fake_erlexec.reboot
+++ b/tests/fake_erlexec.reboot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo "erlexec is sending signal to reboot" 1>&2
 

--- a/tests/fake_erlexec.segfault
+++ b/tests/fake_erlexec.segfault
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo "erlexec is going to crash" 1>&2
 

--- a/tests/fake_erlexec.ungraceful_halt
+++ b/tests/fake_erlexec.ungraceful_halt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo "erlexec is sending signal to halt" 1>&2
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # "readlink -f" implementation for BSD
 # This code was extracted from the Elixir shell scripts

--- a/tests/run_tests_impl.sh
+++ b/tests/run_tests_impl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # "readlink -f" implementation for BSD
 # This code was extracted from the Elixir shell scripts


### PR DESCRIPTION
This updates them to use `env` and always uses `bash` rather than a mix
of `bash` and `sh`. The use of `env` helps users who have `bash` in
other locations such as on NixOS and when installing `bash` with
Homebrew on Macs.
