### PR TITLE
Prefer ERTS found in release over system ERTS

### DIFF
--- a/tests/058_start_erl_tries_release_erts_first
+++ b/tests/058_start_erl_tries_release_erts_first
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+#
+# Test that an erts bundled with a release is used in preference to the
+# system erts when using a start_erl.data file.
+#
+
+cat >"$CMDLINE_FILE" <<EOF
+-v
+EOF
+
+RELEASE_PATH=$WORK/srv/erlang/releases
+RELEASE_VERSION_PATH=$WORK/srv/erlang/releases/0.0.1
+mkdir -p $RELEASE_VERSION_PATH
+
+touch $RELEASE_VERSION_PATH/erelease.rel
+touch $RELEASE_VERSION_PATH/start.boot
+touch $RELEASE_VERSION_PATH/sys.config
+touch $RELEASE_VERSION_PATH/vm.args
+
+touch $RELEASE_PATH/erelease.rel
+touch $RELEASE_PATH/RELEASES
+
+# Use same version as erts in /usr/lib/erlang to make sure that both
+# system and release erts's can be chosen.
+mkdir -p $WORK/srv/erlang/erts-6.0/bin
+ln -s $FAKE_ERLEXEC $WORK/srv/erlang/erts-6.0/bin/erlexec
+
+cat >$WORK/srv/erlang/releases/start_erl.data <<EOF
+6.0 0.0.1
+EOF
+
+cat >"$EXPECTED" <<EOF
+erlinit: cmdline argc=2, merged argc=2
+erlinit: merged argv[0]=/sbin/init
+erlinit: merged argv[1]=-v
+fixture: mount("proc", "/proc", "proc", 14, data)
+fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
+fixture: mkdir("/dev/pts", 755)
+fixture: mkdir("/dev/shm", 1777)
+fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
+fixture: symlink("/dev/mmcblk0","/dev/rootdisk0")
+fixture: symlink("/dev/mmcblk0p4","/dev/rootdisk0p4")
+fixture: symlink("/dev/mmcblk0p3","/dev/rootdisk0p3")
+fixture: symlink("/dev/mmcblk0p2","/dev/rootdisk0p2")
+fixture: symlink("/dev/mmcblk0p1","/dev/rootdisk0p1")
+erlinit: set_ctty
+fixture: setsid()
+fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
+fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
+erlinit: find_release
+erlinit: Using release in /srv/erlang/releases/0.0.1.
+erlinit: find_sys_config
+erlinit: find_vm_args
+erlinit: find_boot_path
+erlinit: find_erts_directory
+erlinit: setup_environment
+erlinit: setup_networking
+fixture: ioctl(SIOCGIFFLAGS)
+fixture: ioctl(SIOCSIFFLAGS)
+fixture: ioctl(SIOCGIFINDEX)
+erlinit: configure_hostname
+erlinit: /etc/hostname not found
+erlinit: Env: 'HOME=/home/user0'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/srv/erlang'
+erlinit: Env: 'BINDIR=/srv/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erlexec'
+erlinit: Env: 'RELEASE_SYS_CONFIG=/srv/erlang/releases/0.0.1/sys'
+erlinit: Env: 'RELEASE_ROOT=/srv/erlang'
+erlinit: Env: 'RELEASE_TMP=/tmp'
+erlinit: Arg: 'erlexec'
+erlinit: Arg: '-config'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/sys.config'
+erlinit: Arg: '-boot'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/start'
+erlinit: Arg: '-args_file'
+erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
+erlinit: Launching erl...
+Hello from erlexec
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: Sending SIGTERM to all processes
+fixture: kill(-1, 15)
+fixture: sleep(1)
+erlinit: Sending SIGKILL to all processes
+fixture: kill(-1, 9)
+erlinit: unmount_all
+erlinit: unmounting tmpfs at /sys/fs/cgroup...
+fixture: umount("/sys/fs/cgroup")
+erlinit: unmounting tmpfs at /dev/shm...
+fixture: umount("/dev/shm")
+erlinit: unmounting devpts at /dev/pts...
+fixture: umount("/dev/pts")
+erlinit: unmounting proc at /proc...
+fixture: umount("/proc")
+erlinit: unmounting sysfs at /sys...
+fixture: umount("/sys")
+EOF


### PR DESCRIPTION
This changes the default behavior of only using the system ERTS when
`--release-include-erts` isn't specified. The new behavior is to try the
release's ERTS first and then fallback to the system ERTS. The auto-ERTS
finding code isn't modified, but it also shouldn't be exercised much at
all any more.

The reasons for this change are:

1. Using the ERTS supplied in an OTP release is preferred everywhere I
   look these days. People will probably be surprised if it's not used.
2. Nerves currently uses ERTS from `/usr/lib/erlang`, but I'd like to
   change it to install ERTS with the release for consistency. Without
   this change, `--release-include-erts` would need to be added to all
   systems and it seems much easier to make erlinit "smarter".
3. OTP 25 uses `$ROOTDIR` more places. Running ERTS from the release
   gets rid of some confusion on where it needs to point. The confusion
   could be mine, but keeping ERTS with the release removes the issue.
