### PR TITLE
Support relative paths to ERTS-supplied binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,7 @@
   * Support merging commandline arguments together so that it's possible to
     launch erlang via `run_erl`. This is required since `run_erl` runs
     `sh -c` to start Erlang up and that requires all arguments to be passed
-    as a long string. Example: `-s "/usr/bin/run_erl /tmp/ /tmp exec"`
+    as a long string. Example: `-s "run_erl /tmp/ /tmp exec"`
 
 ## v1.4.8
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,10 @@ The following lists the options:
     Run the specified command on exit.
 
 -s, --alternate-exec <program and arguments>
-    Run another program that starts Erlang up. The arguments to `erlexec` are passed afterwards.
+    Run another program that starts Erlang up. The arguments to `erlexec` are
+    passed afterwards. This requires an absolute path to the program unless
+    you're running a program out of the ERTS directory. For example, to run
+    `run_erl`, just pass `run_erl`.
 
 --shutdown-report <path>
     Before shutting down or rebooting, save a report to the specified path.
@@ -338,6 +341,11 @@ section. Another use is to capture the Erlang console to a pipe and redirect it
 to a GUI or web app. The `dtach` utility is useful for this. An example
 invocation is: `--alternate-exec "/usr/bin/dtach -N /tmp/iex_prompt"`.  See the
 `dtach` manpage for details.
+
+IMPORTANT: Use absolute paths to the programs that you want to run unless they
+are supplied by the Erlang runtime. `erlinit` knows about the Erlang runtime and
+will find the proper Erlang runtime binary (like `run_erl`), if you just pass
+the program name.
 
 ## Multiple consoles
 

--- a/src/erlinit.c
+++ b/src/erlinit.c
@@ -714,6 +714,7 @@ static void child()
 
     // Start Erlang up
     char erlexec_path[ERLINIT_PATH_MAX];
+    char alternate_exec_path[ERLINIT_PATH_MAX];
     sprintf(erlexec_path, "%s/bin/erlexec", run_info.erts_dir);
     char *exec_path = erlexec_path;
 
@@ -722,10 +723,18 @@ static void child()
 
     char **argv = exec_argv;
     // If there's an alternate exec and it's set properly, then use it.
-    char *alternate_exec_path = strtok(options.alternate_exec, " ");
+    char *alternate_exec_program = strtok(options.alternate_exec, " ");
     int append = 0;
-    if (options.alternate_exec && alternate_exec_path && alternate_exec_path[0] != '\0') {
-        exec_path = alternate_exec_path;
+    if (options.alternate_exec && alternate_exec_program && alternate_exec_program[0] != '\0') {
+        // If the alternate exec is a relative path, force it to the ERTS
+        // directory. Otherwise the user should pass absolute paths.
+        if (alternate_exec_program[0] == '/') {
+            exec_path = alternate_exec_program;
+        } else {
+            sprintf(alternate_exec_path, "%s/bin/%s", run_info.erts_dir, alternate_exec_program);
+            exec_path = alternate_exec_path;
+        }
+
         argv = concat_options(argv, exec_path, 0); // argv0
 
         char *arg;

--- a/tests/059_alternate_exec_run_erl
+++ b/tests/059_alternate_exec_run_erl
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+#
+# Test that using alternate_exec with a relative path searches
+# the erts bin directory in the release
+#
+# This is needed if you want to run any Erlang-supplied binaries
+# as the alternate_exec. The `run_erl` binary is the one that
+# motivated this.
+#
+
+cat >"$CONFIG" <<EOF
+-v --alternate-exec "run_erl 1 2 exec 3"
+EOF
+
+RELEASE_PATH=$WORK/srv/erlang/releases
+RELEASE_VERSION_PATH=$WORK/srv/erlang/releases/0.0.1
+mkdir -p $RELEASE_VERSION_PATH
+
+touch $RELEASE_VERSION_PATH/erelease.rel
+touch $RELEASE_VERSION_PATH/sys.config
+touch $RELEASE_VERSION_PATH/vm.args
+
+touch $RELEASE_PATH/erelease.rel
+touch $RELEASE_PATH/RELEASES
+
+mkdir -p $WORK/srv/erlang/erts-6.0/bin
+ln -s $FAKE_ERLEXEC $WORK/srv/erlang/erts-6.0/bin/erlexec
+cat >$RELEASE_PATH/start_erl.data <<EOF
+6.0 0.0.1
+EOF
+
+cat >$WORK/srv/erlang/erts-6.0/bin/run_erl <<EOF
+#!/usr/bin/env bash
+
+echo Hello from run_erl 1>&2
+echo Args: 1>&2
+for i; do
+  echo "  \$i" 1>&2
+done
+EOF
+chmod +x $WORK/srv/erlang/erts-6.0/bin/run_erl
+
+RELEASE_PATH=$WORK/srv/erlang/releases/0.0.1
+mkdir -p $RELEASE_PATH
+touch $RELEASE_PATH/test.boot
+touch $RELEASE_PATH/sys.config
+touch $RELEASE_PATH/vm.args
+
+cat >"$EXPECTED" <<EOF
+erlinit: cmdline argc=1, merged argc=4
+erlinit: merged argv[0]=/sbin/init
+erlinit: merged argv[1]=-v
+erlinit: merged argv[2]=--alternate-exec
+erlinit: merged argv[3]=run_erl 1 2 exec 3
+fixture: mount("proc", "/proc", "proc", 14, data)
+fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
+fixture: mkdir("/dev/pts", 755)
+fixture: mkdir("/dev/shm", 1777)
+fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
+fixture: symlink("/dev/mmcblk0","/dev/rootdisk0")
+fixture: symlink("/dev/mmcblk0p4","/dev/rootdisk0p4")
+fixture: symlink("/dev/mmcblk0p3","/dev/rootdisk0p3")
+fixture: symlink("/dev/mmcblk0p2","/dev/rootdisk0p2")
+fixture: symlink("/dev/mmcblk0p1","/dev/rootdisk0p1")
+erlinit: set_ctty
+fixture: setsid()
+fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
+fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
+erlinit: find_release
+erlinit: Using release in /srv/erlang/releases/0.0.1.
+erlinit: find_sys_config
+erlinit: find_vm_args
+erlinit: find_boot_path
+erlinit: find_erts_directory
+erlinit: setup_environment
+erlinit: setup_networking
+fixture: ioctl(SIOCGIFFLAGS)
+fixture: ioctl(SIOCSIFFLAGS)
+fixture: ioctl(SIOCGIFINDEX)
+erlinit: configure_hostname
+erlinit: /etc/hostname not found
+erlinit: Env: 'HOME=/home/user0'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/srv/erlang'
+erlinit: Env: 'BINDIR=/srv/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erlexec'
+erlinit: Env: 'RELEASE_SYS_CONFIG=/srv/erlang/releases/0.0.1/sys'
+erlinit: Env: 'RELEASE_ROOT=/srv/erlang'
+erlinit: Env: 'RELEASE_TMP=/tmp'
+erlinit: Arg: '/srv/erlang/erts-6.0/bin/run_erl'
+erlinit: Arg: '1'
+erlinit: Arg: '2'
+erlinit: Arg: 'exec 3 /srv/erlang/erts-6.0/bin/erlexec -config /srv/erlang/releases/0.0.1/sys.config -boot /srv/erlang/releases/0.0.1/test -args_file /srv/erlang/releases/0.0.1/vm.args -boot_var RELEASE_LIB /srv/erlang/lib'
+erlinit: Launching erl...
+Hello from run_erl
+Args:
+  1
+  2
+  exec 3 /srv/erlang/erts-6.0/bin/erlexec -config /srv/erlang/releases/0.0.1/sys.config -boot /srv/erlang/releases/0.0.1/test -args_file /srv/erlang/releases/0.0.1/vm.args -boot_var RELEASE_LIB /srv/erlang/lib
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: Sending SIGTERM to all processes
+fixture: kill(-1, 15)
+fixture: sleep(1)
+erlinit: Sending SIGKILL to all processes
+fixture: kill(-1, 9)
+erlinit: unmount_all
+erlinit: unmounting tmpfs at /sys/fs/cgroup...
+fixture: umount("/sys/fs/cgroup")
+erlinit: unmounting tmpfs at /dev/shm...
+fixture: umount("/dev/shm")
+erlinit: unmounting devpts at /dev/pts...
+fixture: umount("/dev/pts")
+erlinit: unmounting proc at /proc...
+fixture: umount("/proc")
+erlinit: unmounting sysfs at /sys...
+fixture: umount("/sys")
+EOF


### PR DESCRIPTION
When the ERTS directory started being included in the OTP release (a
good thing), running `run_erl` as an alternate-exec program became
brittle. The reason is that the ERTS directory includes a version number
so you have to update the path to `run_erl` every Erlang/OTP update.

This makes it possible to pass a relative path to the alternate-exec
option and let `erlinit` make it point to the ERTS supplied bin
directory.
