### PR TITLE
Fix typo of --working-directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The following lists the options:
 --warn-unused-tty
     Print a message on ttys receiving kernel logs, but not an Erlang console
 
---working_directory <path>
+--working-directory <path>
     Set the working directory
 
 --x-pivot-root-on-overlayfs

--- a/src/options.c
+++ b/src/options.c
@@ -224,7 +224,7 @@ void parse_args(int argc, char *argv[])
         case OPT_PRE_RUN_EXEC: // --pre-run-exec /bin/special-init
             SET_STRING_OPTION(options.pre_run_exec);
             break;
-        case OPT_WORKING_DIRECTORY: // --working_directory /root
+        case OPT_WORKING_DIRECTORY: // --working-directory /root
             SET_STRING_OPTION(options.working_directory);
             break;
         case OPT_GRACEFUL_SHUTDOWN_TIMEOUT: // --graceful-shutdown-timeout 10000


### PR DESCRIPTION
This commit is backward compatible, because the option's implementation and tests were written correctly before this commit.