### PR TITLE
Add an explanation for `--env` option that can be specified multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The following lists the options:
 
 -e, --env <VAR=value;VAR2=Value2...>
     Set additional environment variables
+    Specify multiple times for a line contains more than 128 characters.
 
 --gid <id>
     Run the Erlang VM under the specified group ID


### PR DESCRIPTION
[OPT_ENV uses `APPEND_STRING_OPTION`](https://github.com/nerves-project/erlinit/blob/534850f8634ea199338a82dc272ffeee622eb28f/src/options.c#L167-L168), so `-e, --env` option can be specified multiple times, so added the fact to README.

Why added the explanation, I faced a case where a defined environment variable was chopped in the middle.

One line max characters is defined [here](https://github.com/nerves-project/erlinit/blob/534850f8634ea199338a82dc272ffeee622eb28f/src/cfgloader.c#L102-L103).

Thank you always, Nerves team!!
