### PR TITLE
Increase max config line len to 255; truncate afterwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The following lists the options:
 
 -e, --env <VAR=value;VAR2=Value2...>
     Set additional environment variables
-    Specify multiple times for a line contains more than 128 characters.
+    Specify multiple times to break up long lines and avoid 255 character max line length
 
 --gid <id>
     Run the Erlang VM under the specified group ID

--- a/tests/060_long_env
+++ b/tests/060_long_env
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+#
+# Test long commandline options
+#
+# Checks:
+# * Long commandline options aren't trimmed
+# * Config file options can be up to 255 characters
+# * Config file options that are longer are truncated and the rest of the line ignored
+#
+cat >"$CMDLINE_FILE" <<EOF
+-v
+--env LANG=en_US.UTF-8;LANGUAGE=en
+--env CMDLINE_LONG=12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456
+EOF
+
+cat >"$CONFIG" <<EOF
+# 255 characters
+--env CONFIG_FILE_LONG=1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+
+# 256 characters
+--env CONFIG_FILE_TRIM=12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123
+EOF
+
+cat >"$EXPECTED" <<EOF
+erlinit: cmdline argc=6, merged argc=10
+erlinit: merged argv[0]=/sbin/init
+erlinit: merged argv[1]=--env
+erlinit: merged argv[2]=CONFIG_FILE_LONG=1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+erlinit: merged argv[3]=--env
+erlinit: merged argv[4]=CONFIG_FILE_TRIM=1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+erlinit: merged argv[5]=-v
+erlinit: merged argv[6]=--env
+erlinit: merged argv[7]=LANG=en_US.UTF-8;LANGUAGE=en
+erlinit: merged argv[8]=--env
+erlinit: merged argv[9]=CMDLINE_LONG=12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456
+fixture: mount("proc", "/proc", "proc", 14, data)
+fixture: mount("sysfs", "/sys", "sysfs", 14, data)
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
+fixture: mkdir("/dev/pts", 755)
+fixture: mkdir("/dev/shm", 1777)
+fixture: mount("devpts", "/dev/pts", "devpts", 10, data)
+fixture: symlink("/dev/mmcblk0","/dev/rootdisk0")
+fixture: symlink("/dev/mmcblk0p4","/dev/rootdisk0p4")
+fixture: symlink("/dev/mmcblk0p3","/dev/rootdisk0p3")
+fixture: symlink("/dev/mmcblk0p2","/dev/rootdisk0p2")
+fixture: symlink("/dev/mmcblk0p1","/dev/rootdisk0p1")
+erlinit: set_ctty
+fixture: setsid()
+fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
+fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
+erlinit: find_release
+erlinit: No release found in /srv/erlang.
+erlinit: find_erts_directory
+erlinit: setup_environment
+erlinit: setup_networking
+fixture: ioctl(SIOCGIFFLAGS)
+fixture: ioctl(SIOCSIFFLAGS)
+fixture: ioctl(SIOCGIFINDEX)
+erlinit: configure_hostname
+erlinit: /etc/hostname not found
+erlinit: Env: 'HOME=/home/user0'
+erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
+erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
+erlinit: Env: 'EMU=beam'
+erlinit: Env: 'PROGNAME=erlexec'
+erlinit: Env: 'CONFIG_FILE_LONG=1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012'
+erlinit: Env: 'CONFIG_FILE_TRIM=1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012'
+erlinit: Env: 'LANG=en_US.UTF-8'
+erlinit: Env: 'LANGUAGE=en'
+erlinit: Env: 'CMDLINE_LONG=12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456'
+erlinit: Arg: 'erlexec'
+erlinit: Arg: '-boot_var'
+erlinit: Arg: 'RELEASE_LIB'
+erlinit: Arg: '/srv/erlang/lib'
+erlinit: Launching erl...
+Hello from erlexec
+erlinit: Erlang VM exited
+erlinit: kill_all
+erlinit: Sending SIGTERM to all processes
+fixture: kill(-1, 15)
+fixture: sleep(1)
+erlinit: Sending SIGKILL to all processes
+fixture: kill(-1, 9)
+erlinit: unmount_all
+erlinit: unmounting tmpfs at /sys/fs/cgroup...
+fixture: umount("/sys/fs/cgroup")
+erlinit: unmounting tmpfs at /dev/shm...
+fixture: umount("/dev/shm")
+erlinit: unmounting devpts at /dev/pts...
+fixture: umount("/dev/pts")
+erlinit: unmounting proc at /proc...
+fixture: umount("/proc")
+erlinit: unmounting sysfs at /sys...
+fixture: umount("/sys")
+EOF


### PR DESCRIPTION
This increases the max line length from 127 characters to 255, since
it's possible to have long environment variable strings. It also
truncates characters after the 255 line length limit so that they don't
accidentally create other options and confuse things further.
