### PR TITLE
Switch from vt100 to xterm to avoid output delays

### DIFF
--- a/src/erlinit.c
+++ b/src/erlinit.c
@@ -532,7 +532,7 @@ static void setup_environment(const struct erl_run_info *run_info)
     // PATH appears to only be needed for user convenience when running os:cmd/1
     // It may be possible to remove in the future.
     putenv("PATH=/usr/sbin:/usr/bin:/sbin:/bin");
-    putenv("TERM=vt100");
+    putenv("TERM=xterm-256color");
 
     // Erlang environment
 

--- a/tests/001_cmdline_verbose
+++ b/tests/001_cmdline_verbose
@@ -39,7 +39,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/002_config_verbose
+++ b/tests/002_config_verbose
@@ -39,7 +39,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/003_run_release
+++ b/tests/003_run_release
@@ -49,7 +49,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/004_run_deep_release
+++ b/tests/004_run_deep_release
@@ -50,7 +50,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang/myrelease'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/005_run_strace
+++ b/tests/005_run_strace
@@ -51,7 +51,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/006_env
+++ b/tests/006_env
@@ -41,7 +41,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/007_multi_release_paths
+++ b/tests/007_multi_release_paths
@@ -52,7 +52,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/008_cmdline_verbose2
+++ b/tests/008_cmdline_verbose2
@@ -39,7 +39,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -44,7 +44,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/010_uniqueid
+++ b/tests/010_uniqueid
@@ -58,7 +58,7 @@ erlinit: Hostname: nerves-0042
 fixture: sethostname("nerves-0042", 11)
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/011_etc_hostname
+++ b/tests/011_etc_hostname
@@ -44,7 +44,7 @@ erlinit: Hostname: myhostname
 fixture: sethostname("myhostname", 10)
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/012_bad_option
+++ b/tests/012_bad_option
@@ -41,7 +41,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/013_bad_option2
+++ b/tests/013_bad_option2
@@ -41,7 +41,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/014_tty_warning
+++ b/tests/014_tty_warning
@@ -55,7 +55,7 @@ erlinit: /etc/hostname not found
 erlinit: warn_unused_tty
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/015_multi_mount
+++ b/tests/015_multi_mount
@@ -48,7 +48,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/016_erlexec_boot_arg
+++ b/tests/016_erlexec_boot_arg
@@ -41,7 +41,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/017_erlexec_boot_arg_file
+++ b/tests/017_erlexec_boot_arg_file
@@ -41,7 +41,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/018_run_on_exit
+++ b/tests/018_run_on_exit
@@ -58,7 +58,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/019_uid_and_gid
+++ b/tests/019_uid_and_gid
@@ -48,7 +48,7 @@ erlinit: setting uid to 100
 fixture: setuid(100)
 erlinit: Env: 'HOME=/home/user100'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/020_pre_run_exec
+++ b/tests/020_pre_run_exec
@@ -60,7 +60,7 @@ erlinit: run_cmd '/usr/bin/prerun'
 Hello from prerun
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/021_multi_boot_script
+++ b/tests/021_multi_boot_script
@@ -53,7 +53,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/022_pick_boot_script
+++ b/tests/022_pick_boot_script
@@ -56,7 +56,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/023_pick_boot_script2
+++ b/tests/023_pick_boot_script2
@@ -56,7 +56,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/024_pick_missing_boot_script
+++ b/tests/024_pick_missing_boot_script
@@ -57,7 +57,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/025_start_erl_data
+++ b/tests/025_start_erl_data
@@ -61,7 +61,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/026_bad_start_erl_data
+++ b/tests/026_bad_start_erl_data
@@ -64,7 +64,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/027_bad_start_erl_data2
+++ b/tests/027_bad_start_erl_data2
@@ -63,7 +63,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/028_boot_script_preference
+++ b/tests/028_boot_script_preference
@@ -53,7 +53,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang/c'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/029_funny_named_boot_script
+++ b/tests/029_funny_named_boot_script
@@ -54,7 +54,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang/myrelease'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/030_graceful_halt
+++ b/tests/030_graceful_halt
@@ -50,7 +50,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/031_graceful_reboot
+++ b/tests/031_graceful_reboot
@@ -50,7 +50,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/032_graceful_poweroff
+++ b/tests/032_graceful_poweroff
@@ -50,7 +50,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/033_ungraceful_halt
+++ b/tests/033_ungraceful_halt
@@ -50,7 +50,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/034_segfault
+++ b/tests/034_segfault
@@ -50,7 +50,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/035_working_directory
+++ b/tests/035_working_directory
@@ -52,7 +52,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/036_bad_working_directory
+++ b/tests/036_bad_working_directory
@@ -53,7 +53,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/037_graceful_timeout
+++ b/tests/037_graceful_timeout
@@ -52,7 +52,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/038_consolidated_protocols
+++ b/tests/038_consolidated_protocols
@@ -53,7 +53,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/039_multi_consolidated
+++ b/tests/039_multi_consolidated
@@ -57,7 +57,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/040_update_clock
+++ b/tests/040_update_clock
@@ -43,7 +43,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/041_uniqueid_whitespace
+++ b/tests/041_uniqueid_whitespace
@@ -58,7 +58,7 @@ erlinit: Hostname: nerves-4
 fixture: sethostname("nerves-4", 8)
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/042_multiple_erts_w_start_erl
+++ b/tests/042_multiple_erts_w_start_erl
@@ -62,7 +62,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-8.3/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/043_bad_uniqueid
+++ b/tests/043_bad_uniqueid
@@ -60,7 +60,7 @@ erlinit: Hostname: nerves-0000
 fixture: sethostname("nerves-0000", 11)
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/044_hostname_bad_chars
+++ b/tests/044_hostname_bad_chars
@@ -44,7 +44,7 @@ erlinit: Hostname: nerves
 fixture: sethostname("nerves", 6)
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/045_hostname_bad_chars2
+++ b/tests/045_hostname_bad_chars2
@@ -44,7 +44,7 @@ erlinit: Hostname: nerves
 fixture: sethostname("nerves", 6)
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/046_hostname_bad_chars3
+++ b/tests/046_hostname_bad_chars3
@@ -44,7 +44,7 @@ erlinit: Hostname: a-bc-de.g
 fixture: sethostname("a-bc-de.g", 9)
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/047_alternate_exec
+++ b/tests/047_alternate_exec
@@ -62,7 +62,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/048_alternate_exec_multiargs
+++ b/tests/048_alternate_exec_multiargs
@@ -62,7 +62,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/049_alternate_exec_exec
+++ b/tests/049_alternate_exec_exec
@@ -66,7 +66,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/050_release_include_erts
+++ b/tests/050_release_include_erts
@@ -71,7 +71,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erelease'
 erlinit: Env: 'BINDIR=/usr/lib/erelease/erts-10.5.6/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/051_rootdisk_exists
+++ b/tests/051_rootdisk_exists
@@ -40,7 +40,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/052_configure_tty
+++ b/tests/052_configure_tty
@@ -44,7 +44,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/053_getpwuid_failure
+++ b/tests/053_getpwuid_failure
@@ -44,7 +44,7 @@ erlinit: setting uid to 1
 fixture: setuid(1)
 erlinit: Env: 'HOME=/root'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/054_shutdown_report
+++ b/tests/054_shutdown_report
@@ -80,7 +80,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/055_pivot_root_on_overlayfs
+++ b/tests/055_pivot_root_on_overlayfs
@@ -50,7 +50,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/056_setrlimit
+++ b/tests/056_setrlimit
@@ -43,7 +43,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/057_setrlimit_multiple
+++ b/tests/057_setrlimit_multiple
@@ -45,7 +45,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/058_start_erl_tries_release_erts_first
+++ b/tests/058_start_erl_tries_release_erts_first
@@ -64,7 +64,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/srv/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/059_alternate_exec_run_erl
+++ b/tests/059_alternate_exec_run_erl
@@ -83,7 +83,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/srv/erlang'
 erlinit: Env: 'BINDIR=/srv/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'

--- a/tests/060_long_env
+++ b/tests/060_long_env
@@ -61,7 +61,7 @@ erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
-erlinit: Env: 'TERM=vt100'
+erlinit: Env: 'TERM=xterm-256color'
 erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
 erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'


### PR DESCRIPTION
The vt100 setting turned out to not be harmless since it would
frequently cause `$<50>` sequences to be output. These tell the terminal
to delay 50 ms. Not all terminals support the output delay sequence so
these sequences would be user-visible.

OTP 26's new tty implementation properly follows terminfo so these
sequences were getting sent. This PR switches the `TERM` environment
variable to `xterm-256color`. The `xterm` terminals are pretty generic
and almost anything supports 256 colors these days. This also was the
default for the Linux and Macs I was using.
