### PR TITLE
Reseed the rng with seedrng

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/elixir:1.6
+      - image: cimg/base:2023.04
 
     working_directory: ~/repo
     steps:

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Except for the regression test code, all code has the following license:
+Except for the regression test code and seedrng.c, all code has the following
+license:
 
 The MIT License (MIT)
 
@@ -26,3 +27,10 @@ To support regression testing on OSX, Linux kernel header files were copied and
 modified to reduce dependencies. These files are in src/compat. None of these
 files are needed to use `erlinit` with Nerves or any other embedded Linux-based
 distribution.
+
+----
+seedrng.c has the following header:
+
+SPDX-License-Identifier: (GPL-2.0 OR Apache-2.0 OR MIT OR BSD-1-Clause OR CC0-1.0)
+
+Copyright (C) 2022 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -396,6 +396,16 @@ builds](https://reproducible-builds.org). Set the
 [SOURCE_DATE_EPOCH](https://reproducible-builds.org/docs/source-date-epoch/)
 environment variable to force the build time to be a constant.
 
+## Random number seeds
+
+Embedded systems usually run a script to save a random number on shutdown that's
+used to initialize the random number generator on the next boot. `erlinit` uses
+[SeedRNG](https://git.zx2c4.com/seedrng/tree/README.md) for this. The seed is
+stored under `/root/seedrng` by default since that's a writable and persisted
+partition on Nerves. SeedRNG is called right before a `--pre-run-exec` and at
+shutdown after all other processes have exited. Errors are ignored, but logged
+as warnings. Specify `-v` to `erlinit` to see some information messages.
+
 ## Hacking
 
 It seems like there are an endless number of small tweaks to `erlinit` that

--- a/src/compat/compat.c
+++ b/src/compat/compat.c
@@ -1,5 +1,6 @@
 #include "compat.h"
 #include <stdio.h>
+#include <string.h>
 #include <errno.h>
 
 static int sigtimedwait_signal = 0;
@@ -64,4 +65,11 @@ int pivot_root(const char *new_root, const char *put_old)
     (void) new_root;
     (void) put_old;
     return 0;
+}
+
+ssize_t getrandom(void *buf, size_t buflen, unsigned int flags)
+{
+    (void) flags;
+    memset(buf, 0xaa, buflen);
+    return buflen;
 }

--- a/src/compat/endian.h
+++ b/src/compat/endian.h
@@ -1,0 +1,8 @@
+#ifndef ENDIAN_H
+#define ENDIAN_H
+
+// Just assume little endian
+#define le32toh(x) (x)
+#define htole32(x) (x)
+
+#endif

--- a/src/compat/linux/random.h
+++ b/src/compat/linux/random.h
@@ -1,0 +1,19 @@
+#ifndef LINUX_RANDOM_H
+#define LINUX_RANDOM_H
+
+#include <sys/types.h>
+
+/* Flags for use with getrandom.  */
+#define GRND_NONBLOCK 0x01
+#define GRND_RANDOM 0x02
+#define GRND_INSECURE 0x04
+
+ssize_t getrandom(void *buf, size_t buflen, unsigned int flags);
+
+// Fake out the RNDADDENTROPY ioctl
+#define RNDADDENTROPY _IOW( 'R', 0x03, int [2] )
+
+// Hack for seedrng.c
+#define CLOCK_BOOTTIME CLOCK_MONOTONIC
+
+#endif

--- a/src/erlinit.c
+++ b/src/erlinit.c
@@ -705,6 +705,16 @@ static void child()
                     run_info.release_base_dir);
     }
 
+    // Restore the seed for the random number generator (failures ignored)
+    //
+    // This has to happen after `mount_filesystems()` and setting up the
+    // environment. Running it before pre_run_exec allows that program to use
+    // random numbers.
+    //
+    // It's not uncommon for pre_run_exec to be used to start hardware entropy
+    // daemons to help with random number generation too.
+    seedrng();
+
     // Optionally run a "pre-run" program
     if (options.pre_run_exec)
         run_cmd(options.pre_run_exec);
@@ -1021,6 +1031,9 @@ int main(int argc, char *argv[])
     // Dump state for post-mortem analysis of why the power off or reboot occurred.
     if (options.shutdown_report)
         shutdown_report_create(options.shutdown_report, &exit_info);
+
+    // Save the seed for the random number generator (failures ignored)
+    seedrng();
 
     // Unmount almost everything.
     unmount_all();

--- a/src/erlinit.h
+++ b/src/erlinit.h
@@ -135,6 +135,9 @@ int system_cmd(const char *cmd, char *output_buffer, int length);
 // Shutdown report
 void shutdown_report_create(const char *path, const struct erlinit_exit_info *info);
 
+// seedrng
+int seedrng(void);
+
 #ifdef __APPLE__
 #include "compat.h"
 #endif

--- a/src/seedrng.c
+++ b/src/seedrng.c
@@ -1,0 +1,489 @@
+// SPDX-License-Identifier: (GPL-2.0 OR Apache-2.0 OR MIT OR BSD-1-Clause OR CC0-1.0)
+/*
+ * Copyright (C) 2022 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
+ */
+
+#include <linux/random.h>
+#include <sys/random.h>
+#include <sys/ioctl.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <unistd.h>
+#include <time.h>
+#include <errno.h>
+#include <endian.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef LOCALSTATEDIR
+//#define LOCALSTATEDIR "/var/lib"
+// For Nerves, /root is persisted and writable
+#define LOCALSTATEDIR "/root"
+#endif
+
+// erlinit.h
+void debug(const char *fmt, ...);
+void warn(const char *fmt, ...);
+
+#define SEED_DIR LOCALSTATEDIR "/seedrng"
+#define CREDITABLE_SEED "seed.credit"
+#define NON_CREDITABLE_SEED "seed.no-credit"
+
+enum blake2s_lengths {
+	BLAKE2S_BLOCK_LEN = 64,
+	BLAKE2S_HASH_LEN = 32,
+	BLAKE2S_KEY_LEN = 32
+};
+
+enum seedrng_lengths {
+	MAX_SEED_LEN = 512,
+	MIN_SEED_LEN = BLAKE2S_HASH_LEN
+};
+
+struct blake2s_state {
+	uint32_t h[8];
+	uint32_t t[2];
+	uint32_t f[2];
+	uint8_t buf[BLAKE2S_BLOCK_LEN];
+	unsigned int buflen;
+	unsigned int outlen;
+};
+
+#define le32_to_cpup(a) le32toh(*(a))
+#define cpu_to_le32(a) htole32(a)
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+#endif
+#ifndef DIV_ROUND_UP
+#define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
+#endif
+
+static inline void cpu_to_le32_array(uint32_t *buf, unsigned int words)
+{
+	while (words--) {
+		*buf = cpu_to_le32(*buf);
+		++buf;
+	}
+}
+
+static inline void le32_to_cpu_array(uint32_t *buf, unsigned int words)
+{
+	while (words--) {
+		*buf = le32_to_cpup(buf);
+		++buf;
+	}
+}
+
+static inline uint32_t ror32(uint32_t word, unsigned int shift)
+{
+	return (word >> (shift & 31)) | (word << ((-shift) & 31));
+}
+
+static const uint32_t blake2s_iv[8] = {
+	0x6A09E667UL, 0xBB67AE85UL, 0x3C6EF372UL, 0xA54FF53AUL,
+	0x510E527FUL, 0x9B05688CUL, 0x1F83D9ABUL, 0x5BE0CD19UL
+};
+
+static const uint8_t blake2s_sigma[10][16] = {
+	{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 },
+	{ 14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3 },
+	{ 11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4 },
+	{ 7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8 },
+	{ 9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13 },
+	{ 2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9 },
+	{ 12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11 },
+	{ 13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10 },
+	{ 6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5 },
+	{ 10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0 },
+};
+
+static void blake2s_set_lastblock(struct blake2s_state *state)
+{
+	state->f[0] = -1;
+}
+
+static void blake2s_increment_counter(struct blake2s_state *state, const uint32_t inc)
+{
+	state->t[0] += inc;
+	state->t[1] += (state->t[0] < inc);
+}
+
+static void blake2s_init_param(struct blake2s_state *state, const uint32_t param)
+{
+	int i;
+
+	memset(state, 0, sizeof(*state));
+	for (i = 0; i < 8; ++i)
+		state->h[i] = blake2s_iv[i];
+	state->h[0] ^= param;
+}
+
+static void blake2s_init(struct blake2s_state *state, const size_t outlen)
+{
+	blake2s_init_param(state, 0x01010000 | outlen);
+	state->outlen = outlen;
+}
+
+static void blake2s_compress(struct blake2s_state *state, const uint8_t *block, size_t nblocks, const uint32_t inc)
+{
+	uint32_t m[16];
+	uint32_t v[16];
+	int i;
+
+	while (nblocks > 0) {
+		blake2s_increment_counter(state, inc);
+		memcpy(m, block, BLAKE2S_BLOCK_LEN);
+		le32_to_cpu_array(m, ARRAY_SIZE(m));
+		memcpy(v, state->h, 32);
+		v[ 8] = blake2s_iv[0];
+		v[ 9] = blake2s_iv[1];
+		v[10] = blake2s_iv[2];
+		v[11] = blake2s_iv[3];
+		v[12] = blake2s_iv[4] ^ state->t[0];
+		v[13] = blake2s_iv[5] ^ state->t[1];
+		v[14] = blake2s_iv[6] ^ state->f[0];
+		v[15] = blake2s_iv[7] ^ state->f[1];
+
+#define G(r, i, a, b, c, d) do { \
+	a += b + m[blake2s_sigma[r][2 * i + 0]]; \
+	d = ror32(d ^ a, 16); \
+	c += d; \
+	b = ror32(b ^ c, 12); \
+	a += b + m[blake2s_sigma[r][2 * i + 1]]; \
+	d = ror32(d ^ a, 8); \
+	c += d; \
+	b = ror32(b ^ c, 7); \
+} while (0)
+
+#define ROUND(r) do { \
+	G(r, 0, v[0], v[ 4], v[ 8], v[12]); \
+	G(r, 1, v[1], v[ 5], v[ 9], v[13]); \
+	G(r, 2, v[2], v[ 6], v[10], v[14]); \
+	G(r, 3, v[3], v[ 7], v[11], v[15]); \
+	G(r, 4, v[0], v[ 5], v[10], v[15]); \
+	G(r, 5, v[1], v[ 6], v[11], v[12]); \
+	G(r, 6, v[2], v[ 7], v[ 8], v[13]); \
+	G(r, 7, v[3], v[ 4], v[ 9], v[14]); \
+} while (0)
+		ROUND(0);
+		ROUND(1);
+		ROUND(2);
+		ROUND(3);
+		ROUND(4);
+		ROUND(5);
+		ROUND(6);
+		ROUND(7);
+		ROUND(8);
+		ROUND(9);
+
+#undef G
+#undef ROUND
+
+		for (i = 0; i < 8; ++i)
+			state->h[i] ^= v[i] ^ v[i + 8];
+
+		block += BLAKE2S_BLOCK_LEN;
+		--nblocks;
+	}
+}
+
+static void blake2s_update(struct blake2s_state *state, const void *inp, size_t inlen)
+{
+	const size_t fill = BLAKE2S_BLOCK_LEN - state->buflen;
+	const uint8_t *in = inp;
+
+	if (!inlen)
+		return;
+	if (inlen > fill) {
+		memcpy(state->buf + state->buflen, in, fill);
+		blake2s_compress(state, state->buf, 1, BLAKE2S_BLOCK_LEN);
+		state->buflen = 0;
+		in += fill;
+		inlen -= fill;
+	}
+	if (inlen > BLAKE2S_BLOCK_LEN) {
+		const size_t nblocks = DIV_ROUND_UP(inlen, BLAKE2S_BLOCK_LEN);
+		blake2s_compress(state, in, nblocks - 1, BLAKE2S_BLOCK_LEN);
+		in += BLAKE2S_BLOCK_LEN * (nblocks - 1);
+		inlen -= BLAKE2S_BLOCK_LEN * (nblocks - 1);
+	}
+	memcpy(state->buf + state->buflen, in, inlen);
+	state->buflen += inlen;
+}
+
+static void blake2s_final(struct blake2s_state *state, uint8_t *out)
+{
+	blake2s_set_lastblock(state);
+	memset(state->buf + state->buflen, 0, BLAKE2S_BLOCK_LEN - state->buflen);
+	blake2s_compress(state, state->buf, 1, state->buflen);
+	cpu_to_le32_array(state->h, ARRAY_SIZE(state->h));
+	memcpy(out, state->h, state->outlen);
+}
+
+static ssize_t getrandom_full(void *buf, size_t count, unsigned int flags)
+{
+	ssize_t ret, total = 0;
+	uint8_t *p = buf;
+
+	do {
+		ret = getrandom(p, count, flags);
+		if (ret < 0 && errno == EINTR)
+			continue;
+		else if (ret < 0)
+			return ret;
+		total += ret;
+		p += ret;
+		count -= ret;
+	} while (count);
+	return total;
+}
+
+static ssize_t read_full(int fd, void *buf, size_t count)
+{
+	ssize_t ret, total = 0;
+	uint8_t *p = buf;
+
+	do {
+		ret = read(fd, p, count);
+		if (ret < 0 && errno == EINTR)
+			continue;
+		else if (ret < 0)
+			return ret;
+		else if (ret == 0)
+			break;
+		total += ret;
+		p += ret;
+		count -= ret;
+	} while (count);
+	return total;
+}
+
+static ssize_t write_full(int fd, const void *buf, size_t count)
+{
+	ssize_t ret, total = 0;
+	const uint8_t *p = buf;
+
+	do {
+		ret = write(fd, p, count);
+		if (ret < 0 && errno == EINTR)
+			continue;
+		else if (ret < 0)
+			return ret;
+		total += ret;
+		p += ret;
+		count -= ret;
+	} while (count);
+	return total;
+}
+
+static size_t determine_optimal_seed_len(void)
+{
+	size_t ret = 0;
+	char poolsize_str[11] = { 0 };
+	int fd = open("/proc/sys/kernel/random/poolsize", O_RDONLY);
+
+	if (fd < 0 || read_full(fd, poolsize_str, sizeof(poolsize_str) - 1) < 0) {
+		warn("Unable to determine pool size, falling back to 256 bits");
+		ret = MIN_SEED_LEN;
+	} else
+		ret = DIV_ROUND_UP(strtoul(poolsize_str, NULL, 10), 8);
+	if (fd >= 0)
+		close(fd);
+	if (ret < MIN_SEED_LEN)
+		ret = MIN_SEED_LEN;
+	else if (ret > MAX_SEED_LEN)
+		ret = MAX_SEED_LEN;
+	return ret;
+}
+
+static int read_new_seed(uint8_t *seed, size_t len, bool *is_creditable)
+{
+	ssize_t ret;
+	int urandom_fd;
+
+	*is_creditable = false;
+	ret = getrandom_full(seed, len, GRND_NONBLOCK);
+	if (ret == (ssize_t)len) {
+		*is_creditable = true;
+		return 0;
+	} else if (ret < 0 && errno == ENOSYS) {
+		struct pollfd random_fd = {
+			.fd = open("/dev/random", O_RDONLY),
+			.events = POLLIN
+		};
+		if (random_fd.fd < 0)
+			return -errno;
+		*is_creditable = poll(&random_fd, 1, 0) == 1;
+		close(random_fd.fd);
+	} else if (getrandom_full(seed, len, GRND_INSECURE) == (ssize_t)len)
+		return 0;
+	urandom_fd = open("/dev/urandom", O_RDONLY);
+	if (urandom_fd < 0)
+		return -1;
+	ret = read_full(urandom_fd, seed, len);
+	if (ret == (ssize_t)len)
+		ret = 0;
+	else
+		ret = -errno ? -errno : -EIO;
+	close(urandom_fd);
+	errno = -ret;
+	return ret ? -1 : 0;
+}
+
+static int seed_rng(uint8_t *seed, size_t len, bool credit)
+{
+	struct {
+		int entropy_count;
+		int buf_size;
+		uint8_t buffer[MAX_SEED_LEN];
+	} req = {
+		.entropy_count = credit ? len * 8 : 0,
+		.buf_size = len
+	};
+	int random_fd, ret;
+
+	if (len > sizeof(req.buffer)) {
+		errno = EFBIG;
+		return -1;
+	}
+	memcpy(req.buffer, seed, len);
+
+	random_fd = open("/dev/urandom", O_RDONLY);
+	if (random_fd < 0)
+		return -1;
+	ret = ioctl(random_fd, RNDADDENTROPY, &req);
+	if (ret)
+		ret = -errno ? -errno : -EIO;
+	close(random_fd);
+	errno = -ret;
+	return ret ? -1 : 0;
+}
+
+static int seed_from_file_if_exists(const char *filename, int dfd, bool credit, struct blake2s_state *hash)
+{
+	uint8_t seed[MAX_SEED_LEN];
+	ssize_t seed_len;
+	int fd = -1, ret = 0;
+
+	fd = openat(dfd, filename, O_RDONLY);
+	if (fd < 0 && errno == ENOENT)
+		return 0;
+	else if (fd < 0) {
+		ret = -errno;
+		warn("Unable to open seed file");
+		goto out;
+	}
+	seed_len = read_full(fd, seed, sizeof(seed));
+	if (seed_len < 0) {
+		ret = -errno;
+		warn("Unable to read seed file");
+		goto out;
+	}
+	if ((unlinkat(dfd, filename, 0) < 0 || fsync(dfd) < 0) && seed_len) {
+		ret = -errno;
+		warn("Unable to remove seed after reading, so not seeding");
+		goto out;
+	}
+	if (!seed_len)
+		goto out;
+
+	blake2s_update(hash, &seed_len, sizeof(seed_len));
+	blake2s_update(hash, seed, seed_len);
+
+	debug("Seeding %zd bits %s crediting", seed_len * 8, credit ? "and" : "without");
+	if (seed_rng(seed, seed_len, credit) < 0) {
+		ret = -errno;
+		warn("Unable to seed");
+	}
+
+out:
+	if (fd >= 0)
+		close(fd);
+	errno = -ret;
+	return ret ? -1 : 0;
+}
+
+static bool skip_credit(void)
+{
+	const char *skip = getenv("SEEDRNG_SKIP_CREDIT");
+	return skip && (!strcmp(skip, "1") || !strcasecmp(skip, "true") ||
+			!strcasecmp(skip, "yes") || !strcasecmp(skip, "y"));
+}
+
+int seedrng(void)
+{
+	static const char seedrng_prefix[] = "SeedRNG v1 Old+New Prefix";
+	static const char seedrng_failure[] = "SeedRNG v1 No New Seed Failure";
+	int fd = -1, dfd = -1, program_ret = 0;
+	uint8_t new_seed[MAX_SEED_LEN];
+	size_t new_seed_len;
+	bool new_seed_creditable;
+	struct timespec realtime = { 0 }, boottime = { 0 };
+	struct blake2s_state hash;
+
+	umask(0077);
+
+	blake2s_init(&hash, BLAKE2S_HASH_LEN);
+	blake2s_update(&hash, seedrng_prefix, strlen(seedrng_prefix));
+	clock_gettime(CLOCK_REALTIME, &realtime);
+	clock_gettime(CLOCK_BOOTTIME, &boottime);
+	blake2s_update(&hash, &realtime, sizeof(realtime));
+	blake2s_update(&hash, &boottime, sizeof(boottime));
+
+	if (mkdir(SEED_DIR, 0700) < 0 && errno != EEXIST) {
+		warn("Unable to create seed directory");
+		return 1;
+	}
+
+	dfd = open(SEED_DIR, O_DIRECTORY | O_RDONLY);
+	if (dfd < 0 || flock(dfd, LOCK_EX) < 0) {
+		warn("Unable to lock seed directory");
+		program_ret = 1;
+		goto out;
+	}
+
+	if (seed_from_file_if_exists(NON_CREDITABLE_SEED, dfd, false, &hash) < 0)
+		program_ret |= 1 << 1;
+	if (seed_from_file_if_exists(CREDITABLE_SEED, dfd, !skip_credit(), &hash) < 0)
+		program_ret |= 1 << 2;
+
+	new_seed_len = determine_optimal_seed_len();
+	if (read_new_seed(new_seed, new_seed_len, &new_seed_creditable) < 0) {
+		warn("Unable to read new seed");
+		new_seed_len = BLAKE2S_HASH_LEN;
+		strncpy((char *)new_seed, seedrng_failure, new_seed_len);
+		program_ret |= 1 << 3;
+	}
+	blake2s_update(&hash, &new_seed_len, sizeof(new_seed_len));
+	blake2s_update(&hash, new_seed, new_seed_len);
+	blake2s_final(&hash, new_seed + new_seed_len - BLAKE2S_HASH_LEN);
+
+	debug("Saving %zu bits of %s seed for next boot", new_seed_len * 8, new_seed_creditable ? "creditable" : "non-creditable");
+	fd = openat(dfd, NON_CREDITABLE_SEED, O_WRONLY | O_CREAT | O_TRUNC, 0400);
+	if (fd < 0) {
+		warn("Unable to open seed file for writing");
+		program_ret |= 1 << 4;
+		goto out;
+	}
+	if (write_full(fd, new_seed, new_seed_len) != (ssize_t)new_seed_len || fsync(fd) < 0) {
+		warn("Unable to write seed file");
+		program_ret |= 1 << 5;
+		goto out;
+	}
+	if (new_seed_creditable && renameat(dfd, NON_CREDITABLE_SEED, dfd, CREDITABLE_SEED) < 0) {
+		warn("Unable to make new seed creditable");
+		program_ret |= 1 << 6;
+	}
+out:
+	if (fd >= 0)
+		close(fd);
+	if (dfd >= 0)
+		close(dfd);
+	return program_ret;
+}

--- a/tests/001_cmdline_verbose
+++ b/tests/001_cmdline_verbose
@@ -37,6 +37,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -57,6 +59,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/002_config_verbose
+++ b/tests/002_config_verbose
@@ -37,6 +37,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -57,6 +59,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/003_run_release
+++ b/tests/003_run_release
@@ -47,6 +47,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -76,6 +78,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/004_run_deep_release
+++ b/tests/004_run_deep_release
@@ -48,6 +48,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -77,6 +79,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/005_run_strace
+++ b/tests/005_run_strace
@@ -49,6 +49,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -71,6 +73,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/006_env
+++ b/tests/006_env
@@ -39,6 +39,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -61,6 +63,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/007_multi_release_paths
+++ b/tests/007_multi_release_paths
@@ -50,6 +50,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -79,6 +81,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/008_cmdline_verbose2
+++ b/tests/008_cmdline_verbose2
@@ -37,6 +37,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -57,6 +59,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -42,6 +42,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -62,6 +64,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/010_uniqueid
+++ b/tests/010_uniqueid
@@ -56,6 +56,8 @@ erlinit: configure_hostname
 erlinit: system_cmd '/usr/bin/make-unique-id'
 erlinit: Hostname: nerves-0042
 fixture: sethostname("nerves-0042", 11)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -76,6 +78,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/011_etc_hostname
+++ b/tests/011_etc_hostname
@@ -42,6 +42,8 @@ fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: Hostname: myhostname
 fixture: sethostname("myhostname", 10)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -62,6 +64,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/012_bad_option
+++ b/tests/012_bad_option
@@ -39,6 +39,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -59,6 +61,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/013_bad_option2
+++ b/tests/013_bad_option2
@@ -39,6 +39,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -59,6 +61,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/014_tty_warning
+++ b/tests/014_tty_warning
@@ -53,6 +53,8 @@ fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
 erlinit: warn_unused_tty
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -73,6 +75,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/015_multi_mount
+++ b/tests/015_multi_mount
@@ -46,6 +46,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -66,6 +68,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/016_erlexec_boot_arg
+++ b/tests/016_erlexec_boot_arg
@@ -39,6 +39,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -62,6 +64,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/017_erlexec_boot_arg_file
+++ b/tests/017_erlexec_boot_arg_file
@@ -39,6 +39,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -59,6 +61,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/018_run_on_exit
+++ b/tests/018_run_on_exit
@@ -56,6 +56,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -87,6 +89,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/019_uid_and_gid
+++ b/tests/019_uid_and_gid
@@ -42,6 +42,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: setting gid to 200
 fixture: setgid(200)
 erlinit: setting uid to 100
@@ -66,6 +68,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/020_pre_run_exec
+++ b/tests/020_pre_run_exec
@@ -56,6 +56,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: run_cmd '/usr/bin/prerun'
 Hello from prerun
 erlinit: Env: 'HOME=/home/user0'
@@ -87,6 +89,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/021_multi_boot_script
+++ b/tests/021_multi_boot_script
@@ -51,6 +51,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -80,6 +82,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/022_pick_boot_script
+++ b/tests/022_pick_boot_script
@@ -54,6 +54,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -83,6 +85,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/023_pick_boot_script2
+++ b/tests/023_pick_boot_script2
@@ -54,6 +54,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -83,6 +85,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/024_pick_missing_boot_script
+++ b/tests/024_pick_missing_boot_script
@@ -55,6 +55,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -84,6 +86,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/025_start_erl_data
+++ b/tests/025_start_erl_data
@@ -59,6 +59,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -88,6 +90,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/026_bad_start_erl_data
+++ b/tests/026_bad_start_erl_data
@@ -62,6 +62,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -91,6 +93,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/027_bad_start_erl_data2
+++ b/tests/027_bad_start_erl_data2
@@ -61,6 +61,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -90,6 +92,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/028_boot_script_preference
+++ b/tests/028_boot_script_preference
@@ -51,6 +51,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -80,6 +82,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/029_funny_named_boot_script
+++ b/tests/029_funny_named_boot_script
@@ -52,6 +52,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -81,6 +83,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/030_graceful_halt
+++ b/tests/030_graceful_halt
@@ -48,6 +48,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -79,6 +81,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/031_graceful_reboot
+++ b/tests/031_graceful_reboot
@@ -48,6 +48,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -79,6 +81,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/032_graceful_poweroff
+++ b/tests/032_graceful_poweroff
@@ -48,6 +48,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -79,6 +81,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/033_ungraceful_halt
+++ b/tests/033_ungraceful_halt
@@ -48,6 +48,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -79,6 +81,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/034_segfault
+++ b/tests/034_segfault
@@ -48,6 +48,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -77,6 +79,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/035_working_directory
+++ b/tests/035_working_directory
@@ -50,6 +50,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -79,6 +81,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/036_bad_working_directory
+++ b/tests/036_bad_working_directory
@@ -51,6 +51,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -80,6 +82,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/037_graceful_timeout
+++ b/tests/037_graceful_timeout
@@ -50,6 +50,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -81,6 +83,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/038_consolidated_protocols
+++ b/tests/038_consolidated_protocols
@@ -51,6 +51,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -82,6 +84,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/039_multi_consolidated
+++ b/tests/039_multi_consolidated
@@ -55,6 +55,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -86,6 +88,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/040_update_clock
+++ b/tests/040_update_clock
@@ -41,6 +41,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -61,6 +63,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/041_uniqueid_whitespace
+++ b/tests/041_uniqueid_whitespace
@@ -56,6 +56,8 @@ erlinit: configure_hostname
 erlinit: system_cmd '/usr/bin/make-unique-id'
 erlinit: Hostname: nerves-4
 fixture: sethostname("nerves-4", 8)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -76,6 +78,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/042_multiple_erts_w_start_erl
+++ b/tests/042_multiple_erts_w_start_erl
@@ -60,6 +60,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -89,6 +91,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/043_bad_uniqueid
+++ b/tests/043_bad_uniqueid
@@ -58,6 +58,8 @@ erlinit: system_cmd '/usr/bin/make-unique-id'
 erlinit: '/usr/bin/make-unique-id' failed. Using default ID: '00000000'
 erlinit: Hostname: nerves-0000
 fixture: sethostname("nerves-0000", 11)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -78,6 +80,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/044_hostname_bad_chars
+++ b/tests/044_hostname_bad_chars
@@ -42,6 +42,8 @@ fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: Hostname: nerves
 fixture: sethostname("nerves", 6)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -62,6 +64,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/045_hostname_bad_chars2
+++ b/tests/045_hostname_bad_chars2
@@ -42,6 +42,8 @@ fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: Hostname: nerves
 fixture: sethostname("nerves", 6)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -62,6 +64,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/046_hostname_bad_chars3
+++ b/tests/046_hostname_bad_chars3
@@ -42,6 +42,8 @@ fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: Hostname: a-bc-de.g
 fixture: sethostname("a-bc-de.g", 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -62,6 +64,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/047_alternate_exec
+++ b/tests/047_alternate_exec
@@ -60,6 +60,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -101,6 +103,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/048_alternate_exec_multiargs
+++ b/tests/048_alternate_exec_multiargs
@@ -60,6 +60,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -107,6 +109,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/049_alternate_exec_exec
+++ b/tests/049_alternate_exec_exec
@@ -64,6 +64,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -91,6 +93,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/050_release_include_erts
+++ b/tests/050_release_include_erts
@@ -69,6 +69,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -98,6 +100,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/051_rootdisk_exists
+++ b/tests/051_rootdisk_exists
@@ -38,6 +38,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -58,6 +60,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/052_configure_tty
+++ b/tests/052_configure_tty
@@ -42,6 +42,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -62,6 +64,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/053_getpwuid_failure
+++ b/tests/053_getpwuid_failure
@@ -40,6 +40,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: setting uid to 1
 fixture: setuid(1)
 erlinit: Env: 'HOME=/root'
@@ -62,6 +64,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/054_shutdown_report
+++ b/tests/054_shutdown_report
@@ -78,6 +78,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -110,6 +112,10 @@ fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
 erlinit: Writing shutdown report to '/shutdown.txt'
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/055_pivot_root_on_overlayfs
+++ b/tests/055_pivot_root_on_overlayfs
@@ -48,6 +48,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -68,6 +70,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/056_setrlimit
+++ b/tests/056_setrlimit
@@ -41,6 +41,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -61,6 +63,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/057_setrlimit_multiple
+++ b/tests/057_setrlimit_multiple
@@ -43,6 +43,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -63,6 +65,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/058_start_erl_tries_release_erts_first
+++ b/tests/058_start_erl_tries_release_erts_first
@@ -62,6 +62,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -91,6 +93,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/059_alternate_exec_run_erl
+++ b/tests/059_alternate_exec_run_erl
@@ -81,6 +81,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -108,6 +110,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/060_long_env
+++ b/tests/060_long_env
@@ -59,6 +59,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: /etc/hostname not found
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
@@ -84,6 +86,10 @@ fixture: kill(-1, 15)
 fixture: sleep(1)
 erlinit: Sending SIGKILL to all processes
 fixture: kill(-1, 9)
+fixture: mkdir("/root/seedrng", 700)
+erlinit: Seeding 256 bits and crediting
+fixture: ioctl(RNDADDENTROPY)
+erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: unmount_all
 erlinit: unmounting tmpfs at /sys/fs/cgroup...
 fixture: umount("/sys/fs/cgroup")

--- a/tests/fixture/erlinit_fixture.c
+++ b/tests/fixture/erlinit_fixture.c
@@ -21,6 +21,12 @@
 #include <pwd.h>
 #include <sys/resource.h>
 
+#ifndef __APPLE__
+#include <linux/random.h>
+#else
+#define RNDADDENTROPY _IOW( 'R', 0x03, int [2] )
+#endif
+
 #define log(MSG, ...) do { fprintf(stderr, "fixture: " MSG "\n", ## __VA_ARGS__); } while (0)
 
 #ifndef __APPLE__
@@ -491,6 +497,10 @@ REPLACE(int, ioctl, (int fd, unsigned long request, ...))
         // Ignore FIODTYPE ioctls on OSX.
         return 0;
 #endif
+
+    case RNDADDENTROPY:
+        req = "RNDADDENTROPY";
+        break;
 
     default:
         log("unknown ioctl(0x%08lx)", request);

--- a/tests/run_tests_impl.sh
+++ b/tests/run_tests_impl.sh
@@ -55,6 +55,7 @@ run() {
     ln -s "$ERLINIT" "$WORK/sbin/init"
     mkdir -p "$FAKE_ERTS_DIR/bin"
     ln -s "$FAKE_ERLEXEC" "$FAKE_ERTS_DIR/bin/erlexec"
+    mkdir -p "$WORK/root"
 
     # Create some device files (the fixture sets their types)
     touch "$WORK/dev/mmcblk0" "$WORK/dev/mmcblk0p1" "$WORK/dev/mmcblk0p2" "$WORK/dev/mmcblk0p3" "$WORK/dev/mmcblk0p4"
@@ -100,6 +101,10 @@ devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0
 tmpfs /dev/shm tmpfs rw,nosuid,nodev 0 0
 tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec,mode=755 0 0
 EOF
+    # Fake random info
+    mkdir -p "$WORK/proc/sys/kernel/random"
+    echo "256" > "$WORK/proc/sys/kernel/random/poolsize"
+    touch "$WORK/dev/urandom"
 
     # Run the test script to setup files for the test
     source "$TESTS_DIR/$TEST"


### PR DESCRIPTION
This pulls in seedrng and invokes it on boot and shutdown to save and
restore random number seeds.

Seedrng can be found at https://git.zx2c4.com/seedrng/. Minimal changes
have been made to it to output messages consistent with erlinit. Errors
are ignored, so systems with read-only filesystems or filesystem errors
won't fail.
