### PR TITLE
Sync to disk before the shutdown killing spree

### DIFF
--- a/src/erlinit.c
+++ b/src/erlinit.c
@@ -819,10 +819,13 @@ static void kill_all()
 {
     debug("kill_all");
 
+    // Sync as much as possible to disk before going on the process killing spree to
+    // reduce I/O from the processes exiting.
+    sync();
+
     // Kill processes the nice way
     warn("Sending SIGTERM to all processes");
     kill(-1, SIGTERM);
-    sync();
 
     sleep(1);
 


### PR DESCRIPTION
This probably doesn't matter for most Nerves apps, but there's a comment
in systemd that makes sense about doing it first. See
https://github.com/systemd/systemd/blob/6902da549bfd5313df0802f18fab74d4cc126427/src/shutdown/shutdown.c#L415-L417.
