### PR TITLE
Extend the printf pattern for hostnames for left trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ The following lists the options:
     Specify multiple times for more than one path to mount.
 
 -n, --hostname-pattern <pattern>
-    Specify a hostname for the system. The pattern is a printf(3)
-    pattern. It is passed a unique ID for the board. E.g., "nerves-%.4s"
+    Specify a hostname for the system. The pattern supports a "%[-][.len]s"
+    where len is the length of the unique ID to use and the "-" controls
+    whether the ID is trimmed from the right or left. E.g., "nerves-%.4s"
 
 --pre-run-exec <program and arguments>
     Run the specified command before Erlang starts
@@ -201,7 +202,7 @@ The following lists the options:
 ```
 
 If you're using this in combination with `Nerves` you can customize configration
-via the application env as well. For details see the 
+via the application env as well. For details see the
 [related documentation](https://hexdocs.pm/nerves/advanced-configuration.html#overriding-erlinit-config-from-mix-config).
 
 ## Rebooting or hanging when the Erlang VM exits

--- a/src/hostname.c
+++ b/src/hostname.c
@@ -83,6 +83,63 @@ static void make_rfc1123_compatible(char *s)
     *d = '\0';
 }
 
+static inline int digit2int(char digit)
+{
+    return digit - '0';
+}
+
+static inline int min(int a, int b)
+{
+    if (a < b)
+        return a;
+    else
+        return b;
+}
+
+static void hostname_sprintf(char *output, const char *pattern, const char *serial)
+{
+    // Simple version of sprintf that supports a subset of patterns:
+    //   %s        - Include the whole string
+    //   %.<len>s  - Include len characters of the string starting at the left
+    //   %-.<len>s - Include len characters of the string starting at the right
+    while (*pattern) {
+        if (*pattern == '%') {
+            pattern++;
+            const char *start = serial;
+            int max_len = strlen(serial);
+            int len;
+            if (pattern[0] == 's') {
+                pattern++;
+                len = max_len;
+            } else if (pattern[0] == '.' && isdigit(pattern[1]) && pattern[2] == 's') {
+                len = min(max_len, digit2int(pattern[1]));
+                pattern += 3;
+            } else if (pattern[0] == '.' && isdigit(pattern[1]) && isdigit(pattern[2]) && pattern[3] == 's') {
+                len = min(max_len, digit2int(pattern[1]) * 10 + digit2int(pattern[2]));
+                pattern += 4;
+            } else if (pattern[0] == '-' && pattern[1] == '.' && isdigit(pattern[2]) && pattern[3] == 's') {
+                len = min(max_len, digit2int(pattern[2]));
+                start += max_len - len;
+                pattern += 4;
+            } else if (pattern[0] == '-' && pattern[1] == '.' && isdigit(pattern[2]) && isdigit(pattern[3]) && pattern[4] == 's') {
+                len = min(max_len, digit2int(pattern[2]) * 10 + digit2int(pattern[3]));
+                start += max_len - len;
+                pattern += 5;
+            } else {
+                // Just give up on bad percent escapes. The config file is wrong and
+                // hopefully it will be obvious that the pattern was broke. Don't crash
+                // or error, since this shouldn't mess up booting.
+                break;
+            }
+            memcpy(output, start, len);
+            output += len;
+        } else {
+            *output++ = *pattern++;
+        }
+    }
+    *output = '\0';
+}
+
 void configure_hostname()
 {
     debug("configure_hostname");
@@ -101,7 +158,7 @@ void configure_hostname()
                 warn("`%s` failed. Using default ID: '%s'", options.uniqueid_exec, unique_id);
             }
         }
-        sprintf(hostname, options.hostname_pattern, unique_id);
+        hostname_sprintf(hostname, options.hostname_pattern, unique_id);
         kill_whitespace(hostname);
         make_rfc1123_compatible(hostname);
     } else {

--- a/tests/061_uniqueid_full
+++ b/tests/061_uniqueid_full
@@ -8,7 +8,7 @@ cat >"$CONFIG" <<EOF
 -v
 
 # Specify a hostname pattern that has a unique id part
---hostname-pattern nerves-%.4s
+--hostname-pattern nerves-%s-
 
 # Call out to a dummy unique id generator
 --uniqueid-exec "/usr/bin/make-unique-id"
@@ -26,7 +26,7 @@ erlinit: cmdline argc=1, merged argc=6
 erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 erlinit: merged argv[2]=--hostname-pattern
-erlinit: merged argv[3]=nerves-%.4s
+erlinit: merged argv[3]=nerves-%s-
 erlinit: merged argv[4]=--uniqueid-exec
 erlinit: merged argv[5]=/usr/bin/make-unique-id
 fixture: mount("proc", "/proc", "proc", 14, data)
@@ -54,8 +54,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: system_cmd '/usr/bin/make-unique-id'
-erlinit: Hostname: nerves-1234
-fixture: sethostname("nerves-1234", 11)
+erlinit: Hostname: nerves-12345678-
+fixture: sethostname("nerves-12345678-", 16)
 fixture: mkdir("/root/seedrng", 700)
 erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'

--- a/tests/062_uniqueid_right
+++ b/tests/062_uniqueid_right
@@ -8,7 +8,7 @@ cat >"$CONFIG" <<EOF
 -v
 
 # Specify a hostname pattern that has a unique id part
---hostname-pattern nerves-%.4s
+--hostname-pattern nerves-%-.4s-
 
 # Call out to a dummy unique id generator
 --uniqueid-exec "/usr/bin/make-unique-id"
@@ -26,7 +26,7 @@ erlinit: cmdline argc=1, merged argc=6
 erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 erlinit: merged argv[2]=--hostname-pattern
-erlinit: merged argv[3]=nerves-%.4s
+erlinit: merged argv[3]=nerves-%-.4s-
 erlinit: merged argv[4]=--uniqueid-exec
 erlinit: merged argv[5]=/usr/bin/make-unique-id
 fixture: mount("proc", "/proc", "proc", 14, data)
@@ -54,8 +54,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: system_cmd '/usr/bin/make-unique-id'
-erlinit: Hostname: nerves-1234
-fixture: sethostname("nerves-1234", 11)
+erlinit: Hostname: nerves-5678-
+fixture: sethostname("nerves-5678-", 12)
 fixture: mkdir("/root/seedrng", 700)
 erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'

--- a/tests/063_uniqueid_long_left
+++ b/tests/063_uniqueid_long_left
@@ -8,7 +8,7 @@ cat >"$CONFIG" <<EOF
 -v
 
 # Specify a hostname pattern that has a unique id part
---hostname-pattern nerves-%.4s
+--hostname-pattern nerves-%.10s-
 
 # Call out to a dummy unique id generator
 --uniqueid-exec "/usr/bin/make-unique-id"
@@ -17,7 +17,7 @@ EOF
 cat >"$WORK/usr/bin/make-unique-id" <<EOF
 #!/usr/bin/env bash
 
-echo "12345678"
+echo "123456789abcdef"
 EOF
 chmod +x "$WORK/usr/bin/make-unique-id"
 
@@ -26,7 +26,7 @@ erlinit: cmdline argc=1, merged argc=6
 erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 erlinit: merged argv[2]=--hostname-pattern
-erlinit: merged argv[3]=nerves-%.4s
+erlinit: merged argv[3]=nerves-%.10s-
 erlinit: merged argv[4]=--uniqueid-exec
 erlinit: merged argv[5]=/usr/bin/make-unique-id
 fixture: mount("proc", "/proc", "proc", 14, data)
@@ -54,8 +54,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: system_cmd '/usr/bin/make-unique-id'
-erlinit: Hostname: nerves-1234
-fixture: sethostname("nerves-1234", 11)
+erlinit: Hostname: nerves-123456789a-
+fixture: sethostname("nerves-123456789a-", 18)
 fixture: mkdir("/root/seedrng", 700)
 erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'

--- a/tests/064_uniqueid_long_right
+++ b/tests/064_uniqueid_long_right
@@ -8,7 +8,7 @@ cat >"$CONFIG" <<EOF
 -v
 
 # Specify a hostname pattern that has a unique id part
---hostname-pattern nerves-%.4s
+--hostname-pattern nerves-%-.10s-
 
 # Call out to a dummy unique id generator
 --uniqueid-exec "/usr/bin/make-unique-id"
@@ -17,7 +17,7 @@ EOF
 cat >"$WORK/usr/bin/make-unique-id" <<EOF
 #!/usr/bin/env bash
 
-echo "12345678"
+echo "123456789abcdef"
 EOF
 chmod +x "$WORK/usr/bin/make-unique-id"
 
@@ -26,7 +26,7 @@ erlinit: cmdline argc=1, merged argc=6
 erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 erlinit: merged argv[2]=--hostname-pattern
-erlinit: merged argv[3]=nerves-%.4s
+erlinit: merged argv[3]=nerves-%-.10s-
 erlinit: merged argv[4]=--uniqueid-exec
 erlinit: merged argv[5]=/usr/bin/make-unique-id
 fixture: mount("proc", "/proc", "proc", 14, data)
@@ -54,8 +54,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: system_cmd '/usr/bin/make-unique-id'
-erlinit: Hostname: nerves-1234
-fixture: sethostname("nerves-1234", 11)
+erlinit: Hostname: nerves-6789abcdef-
+fixture: sethostname("nerves-6789abcdef-", 18)
 fixture: mkdir("/root/seedrng", 700)
 erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'

--- a/tests/065_uniqueid_bad
+++ b/tests/065_uniqueid_bad
@@ -8,7 +8,7 @@ cat >"$CONFIG" <<EOF
 -v
 
 # Specify a hostname pattern that has a unique id part
---hostname-pattern nerves-%.4s
+--hostname-pattern nerves-%d-
 
 # Call out to a dummy unique id generator
 --uniqueid-exec "/usr/bin/make-unique-id"
@@ -26,7 +26,7 @@ erlinit: cmdline argc=1, merged argc=6
 erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
 erlinit: merged argv[2]=--hostname-pattern
-erlinit: merged argv[3]=nerves-%.4s
+erlinit: merged argv[3]=nerves-%d-
 erlinit: merged argv[4]=--uniqueid-exec
 erlinit: merged argv[5]=/usr/bin/make-unique-id
 fixture: mount("proc", "/proc", "proc", 14, data)
@@ -54,8 +54,8 @@ fixture: ioctl(SIOCSIFFLAGS)
 fixture: ioctl(SIOCGIFINDEX)
 erlinit: configure_hostname
 erlinit: system_cmd '/usr/bin/make-unique-id'
-erlinit: Hostname: nerves-1234
-fixture: sethostname("nerves-1234", 11)
+erlinit: Hostname: nerves-
+fixture: sethostname("nerves-", 7)
 fixture: mkdir("/root/seedrng", 700)
 erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'


### PR DESCRIPTION
This provides more flexibility in specifying hostname patterns that
include all or part of the board's serial number. Before this change,
"%s" and "%.4s" (4 is the number of characters to use of the serial
number) were supported. After this change, the printf pattern also
supports "%-.4s" to use the rightmost characters in the board's serial
number. This is an extension to printf. I found one reference to someone
else doing this based on web searches and it was the only hit, so it
doesn't look like there's any precedence to follow.

While making this change, the custom sprintf was dumbed down to only
support these escapes and nothing else. This might prevent a crash.
