### PR TITLE
Move a strtok call to avoid unnecessary invocation

### DIFF
--- a/src/erlinit.c
+++ b/src/erlinit.c
@@ -733,9 +733,11 @@ static void child()
 
     char **argv = exec_argv;
     // If there's an alternate exec and it's set properly, then use it.
-    char *alternate_exec_program = strtok(options.alternate_exec, " ");
+    char *alternate_exec_program = NULL;
     int append = 0;
-    if (options.alternate_exec && alternate_exec_program && alternate_exec_program[0] != '\0') {
+    if (options.alternate_exec &&
+        (alternate_exec_program = strtok(options.alternate_exec, " ")) &&
+        alternate_exec_program[0] != '\0') {
         // If the alternate exec is a relative path, force it to the ERTS
         // directory. Otherwise the user should pass absolute paths.
         if (alternate_exec_program[0] == '/') {


### PR DESCRIPTION
This fixes what an unnecessary call to strtok when there's no alternate
exec being passed. It turns out that it's harmless since strtok handles
the NULL being passed in and the result is unused. However, it was
sloppy and identified by clang's sanitize feature. This should prevent
it from being flagged in the future.

Thanks to @jbnoblot for reporting this.
