### PR TITLE
Add --core-pattern and document core dump config

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ The following lists the options:
     Normally, the .boot file is automatically detected. The .boot extension is
     optional. A relative path is relative to the release directory.
 
+--core-pattern <pattern>
+    Specify a pattern for core dumps. This can be a file path like "/data/core".
+    See https://elixir.bootlin.com/linux/v6.11.8/source/Documentation/admin-guide/sysctl/kernel.rst#L144.
+
 -c, --ctty <tty[n]>
     Force the controlling terminal (ttyAMA0, tty1, etc.)
 
@@ -424,6 +428,21 @@ Systemd and Systemd's `reboot` implementation writes the parameter to
 responsible for writing `"tryboot"` to `/run/reboot-param` and then running
 `reboot`. `erlinit` will see file and pass the argument to the kernel as
 intended.
+
+## Saving core dumps early boot
+
+Saving core dumps requires that they be enabled in the Linux kernel and that
+there be a place to write them. Erlinit can make that happen. The configuration
+snippet below shows a line that will mount a writable filesystem at `/root`,
+then set the core pattern to write a file named `core` to that path, and then
+adjust the limits to save an unlimited amount of data to the `core` file. Modify
+to suit your system.
+
+```text
+-m /dev/mmcblk0p1:/root:f2fs:nodev:
+--core-pattern /root/core
+--limit core:unlimited:unlimited
+```
 
 ## Hacking
 

--- a/src/erlinit.h
+++ b/src/erlinit.h
@@ -84,6 +84,7 @@ struct erlinit_options {
     char *shutdown_report;
     char *limits;
     int x_pivot_root_on_overlayfs;
+    char *core_pattern;
 };
 
 extern struct erlinit_options options;

--- a/src/options.c
+++ b/src/options.c
@@ -55,7 +55,8 @@ struct erlinit_options options = {
     .update_clock = 0,
     .shutdown_report = NULL,
     .limits = NULL,
-    .x_pivot_root_on_overlayfs = 0
+    .x_pivot_root_on_overlayfs = 0,
+    .core_pattern = NULL
 };
 
 enum erlinit_option_value {
@@ -92,6 +93,7 @@ enum erlinit_option_value {
     OPT_RELEASE_INCLUDE_ERTS,
     OPT_TTY_OPTIONS,
     OPT_SHUTDOWN_REPORT,
+    OPT_CORE_PATTERN,
 
     // Experimental
     OPT_X_PIVOT_ROOT_ON_OVERLAYFS
@@ -127,6 +129,7 @@ static struct option long_options[] = {
     {"shutdown-report", required_argument, 0, OPT_SHUTDOWN_REPORT},
     {"limits", required_argument, 0, OPT_LIMIT},
     {"x-pivot-root-on-overlayfs", no_argument, 0, OPT_X_PIVOT_ROOT_ON_OVERLAYFS},
+    {"core-pattern", required_argument, 0, OPT_CORE_PATTERN},
     {0,     0,      0, 0 }
 };
 
@@ -241,6 +244,9 @@ void parse_args(int argc, char *argv[])
             break;
         case OPT_X_PIVOT_ROOT_ON_OVERLAYFS: // --x-pivot-root-on-overlayfs
             options.x_pivot_root_on_overlayfs = 1;
+            break;
+        case OPT_CORE_PATTERN: // --core-pattern
+            SET_STRING_OPTION(options.core_pattern);
             break;
         default:
             // getopt prints a warning, so we don't have to

--- a/tests/001_cmdline_verbose
+++ b/tests/001_cmdline_verbose
@@ -54,6 +54,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/002_config_verbose
+++ b/tests/002_config_verbose
@@ -54,6 +54,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/003_run_release
+++ b/tests/003_run_release
@@ -73,6 +73,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/004_run_deep_release
+++ b/tests/004_run_deep_release
@@ -74,6 +74,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/005_run_strace
+++ b/tests/005_run_strace
@@ -68,6 +68,7 @@ erlinit: Launching erl...
 Hello from strace
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/006_env
+++ b/tests/006_env
@@ -58,6 +58,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/007_multi_release_paths
+++ b/tests/007_multi_release_paths
@@ -76,6 +76,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/008_cmdline_verbose2
+++ b/tests/008_cmdline_verbose2
@@ -54,6 +54,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -59,6 +59,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/010_uniqueid
+++ b/tests/010_uniqueid
@@ -73,6 +73,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/011_etc_hostname
+++ b/tests/011_etc_hostname
@@ -59,6 +59,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/012_bad_option
+++ b/tests/012_bad_option
@@ -56,6 +56,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/013_bad_option2
+++ b/tests/013_bad_option2
@@ -56,6 +56,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/014_tty_warning
+++ b/tests/014_tty_warning
@@ -70,6 +70,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/015_multi_mount
+++ b/tests/015_multi_mount
@@ -63,6 +63,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/016_erlexec_boot_arg
+++ b/tests/016_erlexec_boot_arg
@@ -59,6 +59,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/017_erlexec_boot_arg_file
+++ b/tests/017_erlexec_boot_arg_file
@@ -56,6 +56,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/018_run_on_exit
+++ b/tests/018_run_on_exit
@@ -84,6 +84,7 @@ erlinit: Erlang VM exited
 erlinit: run_cmd '/usr/bin/onexit'
 Hello from onexit
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/019_uid_and_gid
+++ b/tests/019_uid_and_gid
@@ -63,6 +63,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/020_pre_run_exec
+++ b/tests/020_pre_run_exec
@@ -84,6 +84,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/021_multi_boot_script
+++ b/tests/021_multi_boot_script
@@ -77,6 +77,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/022_pick_boot_script
+++ b/tests/022_pick_boot_script
@@ -80,6 +80,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/023_pick_boot_script2
+++ b/tests/023_pick_boot_script2
@@ -80,6 +80,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/024_pick_missing_boot_script
+++ b/tests/024_pick_missing_boot_script
@@ -81,6 +81,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/025_start_erl_data
+++ b/tests/025_start_erl_data
@@ -85,6 +85,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/026_bad_start_erl_data
+++ b/tests/026_bad_start_erl_data
@@ -88,6 +88,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/027_bad_start_erl_data2
+++ b/tests/027_bad_start_erl_data2
@@ -87,6 +87,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/028_boot_script_preference
+++ b/tests/028_boot_script_preference
@@ -77,6 +77,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/029_funny_named_boot_script
+++ b/tests/029_funny_named_boot_script
@@ -78,6 +78,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/030_graceful_halt
+++ b/tests/030_graceful_halt
@@ -76,6 +76,7 @@ erlinit: sigpwr|sigusr1 -> halt
 erlinit: waiting 10000 ms for graceful shutdown
 erlinit: graceful shutdown detected
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/031_graceful_reboot
+++ b/tests/031_graceful_reboot
@@ -76,6 +76,7 @@ erlinit: sigterm -> reboot
 erlinit: waiting 10000 ms for graceful shutdown
 erlinit: graceful shutdown detected
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/032_graceful_poweroff
+++ b/tests/032_graceful_poweroff
@@ -76,6 +76,7 @@ erlinit: sigusr2 -> poweroff
 erlinit: waiting 10000 ms for graceful shutdown
 erlinit: graceful shutdown detected
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/033_ungraceful_halt
+++ b/tests/033_ungraceful_halt
@@ -76,6 +76,7 @@ erlinit: sigpwr|sigusr1 -> halt
 erlinit: waiting 10000 ms for graceful shutdown
 erlinit: Graceful shutdown timer expired (10000 ms). Killing Erlang VM process shortly. Adjust timeout with --graceful-shutdown-timeout option.
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/034_segfault
+++ b/tests/034_segfault
@@ -74,6 +74,7 @@ erlinit: Launching erl...
 erlexec is going to crash
 erlinit: Erlang terminated due to signal 11
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/035_working_directory
+++ b/tests/035_working_directory
@@ -76,6 +76,7 @@ erlinit: Launching erl...
 Hello from erlexec in $WORK/tmp
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/036_bad_working_directory
+++ b/tests/036_bad_working_directory
@@ -77,6 +77,7 @@ erlinit: Launching erl...
 Hello from erlexec in $WORK/srv/erlang
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/037_graceful_timeout
+++ b/tests/037_graceful_timeout
@@ -78,6 +78,7 @@ erlinit: sigpwr|sigusr1 -> halt
 erlinit: waiting 15000 ms for graceful shutdown
 erlinit: graceful shutdown detected
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/038_consolidated_protocols
+++ b/tests/038_consolidated_protocols
@@ -79,6 +79,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/039_multi_consolidated
+++ b/tests/039_multi_consolidated
@@ -83,6 +83,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/040_update_clock
+++ b/tests/040_update_clock
@@ -58,6 +58,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/041_uniqueid_whitespace
+++ b/tests/041_uniqueid_whitespace
@@ -73,6 +73,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/043_bad_uniqueid
+++ b/tests/043_bad_uniqueid
@@ -75,6 +75,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/044_hostname_bad_chars
+++ b/tests/044_hostname_bad_chars
@@ -59,6 +59,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/045_hostname_bad_chars2
+++ b/tests/045_hostname_bad_chars2
@@ -59,6 +59,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/046_hostname_bad_chars3
+++ b/tests/046_hostname_bad_chars3
@@ -59,6 +59,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/047_alternate_exec
+++ b/tests/047_alternate_exec
@@ -98,6 +98,7 @@ Args:
   /srv/erlang/lib
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/048_alternate_exec_multiargs
+++ b/tests/048_alternate_exec_multiargs
@@ -104,6 +104,7 @@ Args:
   /srv/erlang/lib
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/049_alternate_exec_exec
+++ b/tests/049_alternate_exec_exec
@@ -88,6 +88,7 @@ Args:
   exec 3 /usr/lib/erlang/erts-6.0/bin/erlexec -config /srv/erlang/releases/0.0.1/sys.config -boot /srv/erlang/releases/0.0.1/test -args_file /srv/erlang/releases/0.0.1/vm.args -boot_var RELEASE_LIB /srv/erlang/lib
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/050_release_include_erts
+++ b/tests/050_release_include_erts
@@ -95,6 +95,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/051_rootdisk_exists
+++ b/tests/051_rootdisk_exists
@@ -55,6 +55,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/052_configure_tty
+++ b/tests/052_configure_tty
@@ -59,6 +59,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/053_getpwuid_failure
+++ b/tests/053_getpwuid_failure
@@ -59,6 +59,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/054_shutdown_report
+++ b/tests/054_shutdown_report
@@ -106,6 +106,7 @@ erlinit: sigterm -> reboot
 erlinit: waiting 10000 ms for graceful shutdown
 erlinit: graceful shutdown detected
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/055_pivot_root_on_overlayfs
+++ b/tests/055_pivot_root_on_overlayfs
@@ -65,6 +65,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/056_setrlimit
+++ b/tests/056_setrlimit
@@ -58,6 +58,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/057_setrlimit_multiple
+++ b/tests/057_setrlimit_multiple
@@ -60,6 +60,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/058_start_erl_tries_release_erts_first
+++ b/tests/058_start_erl_tries_release_erts_first
@@ -88,6 +88,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/059_alternate_exec_run_erl
+++ b/tests/059_alternate_exec_run_erl
@@ -105,6 +105,7 @@ Args:
   exec 3 /srv/erlang/erts-6.0/bin/erlexec -config /srv/erlang/releases/0.0.1/sys.config -boot /srv/erlang/releases/0.0.1/test -args_file /srv/erlang/releases/0.0.1/vm.args -boot_var RELEASE_LIB /srv/erlang/lib
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/060_long_env
+++ b/tests/060_long_env
@@ -81,6 +81,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/061_uniqueid_full
+++ b/tests/061_uniqueid_full
@@ -73,6 +73,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/062_uniqueid_right
+++ b/tests/062_uniqueid_right
@@ -73,6 +73,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/063_uniqueid_long_left
+++ b/tests/063_uniqueid_long_left
@@ -73,6 +73,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/064_uniqueid_long_right
+++ b/tests/064_uniqueid_long_right
@@ -73,6 +73,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/065_uniqueid_bad
+++ b/tests/065_uniqueid_bad
@@ -73,6 +73,7 @@ erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/066_reboot_args
+++ b/tests/066_reboot_args
@@ -79,6 +79,7 @@ erlinit: sigterm -> reboot
 erlinit: waiting 10000 ms for graceful shutdown
 erlinit: graceful shutdown detected
 erlinit: kill_all
+erlinit: Set core pattern to '|/bin/false'
 erlinit: Sending SIGTERM to all processes
 fixture: kill(-1, 15)
 fixture: sleep(1)

--- a/tests/067_core_pattern
+++ b/tests/067_core_pattern
@@ -1,37 +1,19 @@
 #!/usr/bin/env bash
 
 #
-# Test that the start_erl.data file is read when picking a release to run.
+# Test whether the core-pattern option works.
 #
 
 cat >"$CMDLINE_FILE" <<EOF
--v
-EOF
-
-# Make a release
-RELEASE_PATH=$WORK/srv/erlang/releases/0.0.1
-mkdir -p $RELEASE_PATH
-touch $RELEASE_PATH/test.boot
-touch $RELEASE_PATH/sys.config
-touch $RELEASE_PATH/vm.args
-
-# Make a few ERTS directories
-mkdir -p $WORK/usr/lib/erlang/erts-6.1/bin
-mkdir -p $WORK/usr/lib/erlang/erts-7.0/bin
-mkdir -p $WORK/usr/lib/erlang/erts-8.3/bin
-ln -s $FAKE_ERLEXEC $WORK/usr/lib/erlang/erts-6.1/bin/erlexec
-ln -s $FAKE_ERLEXEC $WORK/usr/lib/erlang/erts-7.0/bin/erlexec
-ln -s $FAKE_ERLEXEC $WORK/usr/lib/erlang/erts-8.3/bin/erlexec
-
-# Create a start_erl.data that says which ERTS to use
-cat >$WORK/srv/erlang/releases/start_erl.data <<EOF
-8.3 0.0.1
+-v --core-pattern /data/core
 EOF
 
 cat >"$EXPECTED" <<EOF
-erlinit: cmdline argc=2, merged argc=2
+erlinit: cmdline argc=4, merged argc=4
 erlinit: merged argv[0]=/sbin/init
 erlinit: merged argv[1]=-v
+erlinit: merged argv[2]=--core-pattern
+erlinit: merged argv[3]=/data/core
 fixture: mount("proc", "/proc", "proc", 14, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mount("devtmpfs", "/dev", "devtmpfs", 42, data)
@@ -48,12 +30,10 @@ fixture: setsid()
 fixture: mount("tmpfs", "/tmp", "tmpfs", 14, data)
 fixture: mount("tmpfs", "/run", "tmpfs", 14, data)
 erlinit: find_release
-erlinit: Using release in /srv/erlang/releases/0.0.1.
-erlinit: find_sys_config
-erlinit: find_vm_args
-erlinit: find_boot_path
+erlinit: No release found in /srv/erlang.
 erlinit: find_erts_directory
 erlinit: setup_environment
+erlinit: Set core pattern to '/data/core'
 erlinit: setup_networking
 fixture: ioctl(SIOCGIFFLAGS)
 fixture: ioctl(SIOCSIFFLAGS)
@@ -65,20 +45,11 @@ erlinit: Saving 256 bits of creditable seed for next boot
 erlinit: Env: 'HOME=/home/user0'
 erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
 erlinit: Env: 'TERM=xterm-256color'
-erlinit: Env: 'ROOTDIR=/srv/erlang'
-erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-8.3/bin'
+erlinit: Env: 'ROOTDIR=/usr/lib/erlang'
+erlinit: Env: 'BINDIR=/usr/lib/erlang/erts-6.0/bin'
 erlinit: Env: 'EMU=beam'
 erlinit: Env: 'PROGNAME=erlexec'
-erlinit: Env: 'RELEASE_SYS_CONFIG=/srv/erlang/releases/0.0.1/sys'
-erlinit: Env: 'RELEASE_ROOT=/srv/erlang'
-erlinit: Env: 'RELEASE_TMP=/tmp'
 erlinit: Arg: 'erlexec'
-erlinit: Arg: '-config'
-erlinit: Arg: '/srv/erlang/releases/0.0.1/sys.config'
-erlinit: Arg: '-boot'
-erlinit: Arg: '/srv/erlang/releases/0.0.1/test'
-erlinit: Arg: '-args_file'
-erlinit: Arg: '/srv/erlang/releases/0.0.1/vm.args'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
 erlinit: Arg: '/srv/erlang/lib'


### PR DESCRIPTION
If Erlang crashes right away, it's critical to get a core dump to see
what happened. The default core location wasn't in a writable location
so core dumps were lost. This adds a core pattern option to set where
the dumps should be written and documents the recipe for enabling them.
