### PR TITLE
Compute RELEASE_LIB boot_var at runtime

### DIFF
--- a/src/erlinit.c
+++ b/src/erlinit.c
@@ -795,9 +795,12 @@ static void child()
     }
 
     // Set the RELEASE_LIB boot_var for Elixir 1.9+ releases
+    char *release_lib = NULL;
+    erlinit_asprintf(&release_lib, "%s/lib", run_info.release_base_dir);
     argv = concat_options(argv, "-boot_var", append);
     argv = concat_options(argv, "RELEASE_LIB", append);
-    argv = concat_options(argv, RELEASE_ROOT_LIB, append);
+    argv = concat_options(argv, release_lib, append);
+    free(release_lib);
 
     if (options.verbose) {
         // Dump the environment and commandline

--- a/src/erlinit.h
+++ b/src/erlinit.h
@@ -29,7 +29,6 @@
 #define ERLANG_ERTS_LIB_DIR ERLANG_ROOT_DIR "/lib"
 
 #define DEFAULT_RELEASE_ROOT_DIR "/srv/erlang"
-#define RELEASE_ROOT_LIB DEFAULT_RELEASE_ROOT_DIR "/lib"
 
 // This is the maximum number of mounted filesystems that
 // is expected in a running system. It is used on shutdown
@@ -134,4 +133,3 @@ void trim_whitespace(char *s);
 #endif
 
 #endif // ERLINIT_H
-

--- a/tests/001_cmdline_verbose
+++ b/tests/001_cmdline_verbose
@@ -54,7 +54,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited
@@ -82,4 +82,3 @@ erlinit: unmounting sysfs at /sys...
 fixture: umount("/sys")
 fixture: reboot(0x01234567)
 EOF
-

--- a/tests/002_config_verbose
+++ b/tests/002_config_verbose
@@ -54,7 +54,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/004_run_deep_release
+++ b/tests/004_run_deep_release
@@ -74,7 +74,7 @@ erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/myrelease/releases/0.0.1/vm.args'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/srv/erlang/myrelease/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/005_run_strace
+++ b/tests/005_run_strace
@@ -68,7 +68,7 @@ erlinit: Arg: '-f'
 erlinit: Arg: '/usr/lib/erlang/erts-6.0/bin/erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from strace
 erlinit: Erlang VM exited

--- a/tests/006_env
+++ b/tests/006_env
@@ -58,7 +58,7 @@ erlinit: Env: 'LANGUAGE=en'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/008_cmdline_verbose2
+++ b/tests/008_cmdline_verbose2
@@ -54,7 +54,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/009_mount
+++ b/tests/009_mount
@@ -59,7 +59,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/010_uniqueid
+++ b/tests/010_uniqueid
@@ -73,7 +73,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/011_etc_hostname
+++ b/tests/011_etc_hostname
@@ -59,7 +59,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/012_bad_option
+++ b/tests/012_bad_option
@@ -56,7 +56,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/013_bad_option2
+++ b/tests/013_bad_option2
@@ -56,7 +56,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/014_tty_warning
+++ b/tests/014_tty_warning
@@ -70,7 +70,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/015_multi_mount
+++ b/tests/015_multi_mount
@@ -63,7 +63,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/016_erlexec_boot_arg
+++ b/tests/016_erlexec_boot_arg
@@ -60,7 +60,7 @@ erlinit: Arg: 'ERTS_LIB_DIR'
 erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/017_erlexec_boot_arg_file
+++ b/tests/017_erlexec_boot_arg_file
@@ -57,7 +57,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/019_uid_and_gid
+++ b/tests/019_uid_and_gid
@@ -63,7 +63,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/028_boot_script_preference
+++ b/tests/028_boot_script_preference
@@ -77,7 +77,7 @@ erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/c/releases/0.0.1/vm.args'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/srv/erlang/c/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/029_funny_named_boot_script
+++ b/tests/029_funny_named_boot_script
@@ -78,7 +78,7 @@ erlinit: Arg: '-args_file'
 erlinit: Arg: '/srv/erlang/myrelease/releases/0.0.1/vm.args'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/srv/erlang/myrelease/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/040_update_clock
+++ b/tests/040_update_clock
@@ -58,7 +58,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/041_uniqueid_whitespace
+++ b/tests/041_uniqueid_whitespace
@@ -73,7 +73,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/043_bad_uniqueid
+++ b/tests/043_bad_uniqueid
@@ -75,7 +75,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/044_hostname_bad_chars
+++ b/tests/044_hostname_bad_chars
@@ -59,7 +59,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/045_hostname_bad_chars2
+++ b/tests/045_hostname_bad_chars2
@@ -59,7 +59,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/046_hostname_bad_chars3
+++ b/tests/046_hostname_bad_chars3
@@ -59,7 +59,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/050_release_include_erts
+++ b/tests/050_release_include_erts
@@ -95,7 +95,7 @@ erlinit: Arg: '-args_file'
 erlinit: Arg: '/usr/lib/erelease/releases/0.0.1/vm.args'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erelease/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/051_rootdisk_exists
+++ b/tests/051_rootdisk_exists
@@ -54,7 +54,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/052_configure_tty
+++ b/tests/052_configure_tty
@@ -58,7 +58,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/053_getpwuid_failure
+++ b/tests/053_getpwuid_failure
@@ -59,7 +59,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/055_pivot_root_on_overlayfs
+++ b/tests/055_pivot_root_on_overlayfs
@@ -64,7 +64,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/056_setrlimit
+++ b/tests/056_setrlimit
@@ -58,7 +58,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/057_setrlimit_multiple
+++ b/tests/057_setrlimit_multiple
@@ -60,7 +60,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/060_long_env
+++ b/tests/060_long_env
@@ -80,7 +80,7 @@ erlinit: Env: 'CMDLINE_LONG=1234567890123456789012345678901234567890123456789012
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/061_uniqueid_full
+++ b/tests/061_uniqueid_full
@@ -72,7 +72,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/062_uniqueid_right
+++ b/tests/062_uniqueid_right
@@ -72,7 +72,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/063_uniqueid_long_left
+++ b/tests/063_uniqueid_long_left
@@ -72,7 +72,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/064_uniqueid_long_right
+++ b/tests/064_uniqueid_long_right
@@ -72,7 +72,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/065_uniqueid_bad
+++ b/tests/065_uniqueid_bad
@@ -72,7 +72,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited

--- a/tests/067_core_pattern
+++ b/tests/067_core_pattern
@@ -56,7 +56,7 @@ erlinit: Env: 'PROGNAME=erlexec'
 erlinit: Arg: 'erlexec'
 erlinit: Arg: '-boot_var'
 erlinit: Arg: 'RELEASE_LIB'
-erlinit: Arg: '/srv/erlang/lib'
+erlinit: Arg: '/usr/lib/erlang/lib'
 erlinit: Launching erl...
 Hello from erlexec
 erlinit: Erlang VM exited


### PR DESCRIPTION
I recently opened this issue about the hardcoded RELEASE_LIB boot_var https://github.com/nerves-project/erlinit/issues/127

This variable is expanded by erlexec and it is needed by recent Elixir boot scripts.

This value was hardcoded to be `/srv/erlang/lib`.
This will always be ok if the ROOTDIR where the release is installed is always `/srv/erlang`
Since the release search directory (option "-r") allows to specify arbitrary locations, it is possible that no library is released under `/srv/erlang`.

This may not happen in nerves, but if the user wants to use `erlinit` in other scenarious it is good that the library location is derived from the release installation directory.

This is an example were this fix allows to boot an Elixir release installed in an alternative directory:
```
[   12.099630] erlinit: Env: 'PATH=/usr/sbin:/usr/bin:/sbin:/bin'
[   12.099646] erlinit: Env: 'ROOTDIR=/srv/alloy/hello_elixir'
[   12.099665] erlinit: Env: 'BINDIR=/srv/alloy/hello_elixir/erts-16.0.1/bin'
[   12.099683] erlinit: Env: 'EMU=beam'
[   12.099696] erlinit: Env: 'PROGNAME=erlexec'
[   12.099715] erlinit: Env: 'RELEASE_SYS_CONFIG=/srv/alloy/hello_elixir/releases/0.1.0/sys'
[   12.099729] erlinit: Env: 'RELEASE_ROOT=/srv/alloy/hello_elixir'
[   12.099742] erlinit: Env: 'RELEASE_TMP=/tmp'
[   12.099760] erlinit: Env: 'LANG=en_US.UTF-8'
[   12.099775] erlinit: Env: 'LANGUAGE=en'
[   12.099791] erlinit: Env: 'ERL_INETRC=/etc/erl_inetrc'
[   12.099807] erlinit: Env: 'ERL_CRASH_DUMP=/data/crash/erl_crash.dump'
[   12.099822] erlinit: Env: 'ERL_CRASH_DUMP_SECONDS=5'
[   12.099837] erlinit: Arg: '/usr/bin/nbtty'
[   12.099853] erlinit: Arg: '/srv/alloy/hello_elixir/erts-16.0.1/bin/erlexec'
[   12.099868] erlinit: Arg: '-config'
[   12.099883] erlinit: Arg: '/srv/alloy/hello_elixir/releases/0.1.0/sys.config'
[   12.099902] erlinit: Arg: '-boot'
[   12.099917] erlinit: Arg: '/srv/alloy/hello_elixir/releases/0.1.0/start'
[   12.099933] erlinit: Arg: '-args_file'
[   12.099948] erlinit: Arg: '/srv/alloy/hello_elixir/releases/0.1.0/vm.args'
[   12.099963] erlinit: Arg: '-boot_var'
[   12.099977] erlinit: Arg: 'RELEASE_LIB'
[   12.099992] erlinit: Arg: '/srv/alloy/hello_elixir/lib'.   <<<<<------ this instead of the fixed /srv/erlang/lib
[   12.100008] erlinit: Launching erl...
```

Without this fix we would be forced to put a symlink in the filesystem that makes `/srv/erlang` that points to `/srv/alloy/hello_elixir `

I adapted the tests and I think this change is reasonable. Although I cannot be sure if this could cause any problem in Nerves. I see that `/srv/erlang/lib` would still be computed if `/srv/erlang` is the ROOTDIR.